### PR TITLE
Add PSTFile.close()

### DIFF
--- a/src/main/java/com/pff/PSTFile.java
+++ b/src/main/java/com/pff/PSTFile.java
@@ -899,4 +899,9 @@ public class PSTFile {
 		}
 	}
 
+    public void close() throws IOException
+    {
+        in.close();
+    }
+
 }


### PR DESCRIPTION
Since PSTFile's constructor opens a RandomAccessFile it stands to
reason that a user of this class will want to explicitly control when
this file is closed.

This patch adds the close() method to PSTFile in order to allow
this capability.
