### PR TITLE
PSTFiles can now be constructed using a byte array

### DIFF
--- a/src/main/java/com/pff/PSTByteFileContent.java
+++ b/src/main/java/com/pff/PSTByteFileContent.java
@@ -1,0 +1,36 @@
+package com.pff;
+
+public class PSTByteFileContent extends PSTFileContent{
+    
+    protected byte[] content;
+    protected int index;
+    
+    public PSTByteFileContent(byte[] content){
+        this.content = content;
+        this.index = 0;
+    }
+     
+    public void seek(long index){
+        this.index = (int) index;
+    }
+    public long getFilePointer(){
+        return this.index;
+    }
+    public int read(){
+        return (this.index >= this.content.length) ? -1 : (int) this.content[index++];
+    }
+    public int read(byte[] target){
+        if(this.index >= this.content.length) return -1;
+        int targetindex = 0;
+        while(targetindex < target.length & this.index < this.content.length){
+            target[targetindex++] = this.content[this.index++];
+        }
+        return targetindex;
+    }
+    public byte readByte(){
+        return this.content[index++];
+    }
+    public void close(){
+        // Do nothing
+    }
+}

--- a/src/main/java/com/pff/PSTByteFileContent.java
+++ b/src/main/java/com/pff/PSTByteFileContent.java
@@ -9,7 +9,14 @@ public class PSTByteFileContent extends PSTFileContent{
         this.content = content;
         this.index = 0;
     }
-     
+    
+    public byte[] getBytes(){
+        return this.content;
+    }
+    public void setBytes(byte[] content){
+        this.content = content;
+    }
+    
     public void seek(long index){
         this.index = (int) index;
     }

--- a/src/main/java/com/pff/PSTByteFileContent.java
+++ b/src/main/java/com/pff/PSTByteFileContent.java
@@ -17,15 +17,22 @@ public class PSTByteFileContent extends PSTFileContent{
         this.content = content;
     }
     
+    @Override
     public void seek(long index){
         this.index = (int) index;
     }
+    
+    @Override
     public long getFilePointer(){
         return this.index;
     }
+    
+    @Override
     public int read(){
         return (this.index >= this.content.length) ? -1 : (int) this.content[index++];
     }
+    
+    @Override
     public int read(byte[] target){
         if(this.index >= this.content.length) return -1;
         int targetindex = 0;
@@ -34,10 +41,15 @@ public class PSTByteFileContent extends PSTFileContent{
         }
         return targetindex;
     }
+    
+    @Override
     public byte readByte(){
         return this.content[index++];
     }
+    
+    @Override
     public void close(){
         // Do nothing
     }
+    
 }

--- a/src/main/java/com/pff/PSTFile.java
+++ b/src/main/java/com/pff/PSTFile.java
@@ -33,6 +33,7 @@
  */
 package com.pff;
 import java.io.File;
+import java.io.RandomAccessFile;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -129,7 +130,7 @@ public class PSTFile {
 	public PSTFile(File file)
 		throws FileNotFoundException, PSTException, IOException
 	{
-		this(new PSTRAFFileContent(file));
+		this(new PSTRAFileContent(file));
 	}
 	
 	public PSTFile(byte[] bytes)
@@ -465,12 +466,22 @@ public class PSTFile {
 	}
 	
 	/**
-	 * get the handle to the file we are currently accessing
+	 * get the handle to the RandomAccessFile we are currently accessing (if any)
 	 */
-	public PSTFileContent getFileHandle() {
-		return this.in;
+	public RandomAccessFile getFileHandle() {
+		if(this.in instanceof PSTRAFileContent){
+			return ((PSTRAFileContent) this.in).getFile();
+		}else{
+			return null;
+		}
 	}
 	
+	/**
+	 * get the handle to the file content we are currently accessing
+	 */
+	public PSTFileContent getContentHandle() {
+		return this.in;
+	}
 	
 	/**
 	 * get the message store of the PST file.

--- a/src/main/java/com/pff/PSTFile.java
+++ b/src/main/java/com/pff/PSTFile.java
@@ -32,8 +32,15 @@
  *
  */
 package com.pff;
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Properties;
+import java.util.UUID;
 
 /**
  * PSTFile is the containing class that allows you to access items within a .pst file.
@@ -104,7 +111,7 @@ public class PSTFile {
 	
 	private int itemCount = 0;
 	
-	private RandomAccessFile in;
+	private PSTFileContent in;
 	
 	/**
 	 * constructor
@@ -118,11 +125,24 @@ public class PSTFile {
 	{
 		this(new File(fileName));
 	}
-	public PSTFile(File fileName)
+	
+	public PSTFile(File file)
+		throws FileNotFoundException, PSTException, IOException
+	{
+		this(new PSTRAFFileContent(file));
+	}
+	
+	public PSTFile(byte[] bytes)
+		throws FileNotFoundException, PSTException, IOException
+	{
+		this(new PSTByteFileContent(bytes));
+	}
+	
+	public PSTFile(PSTFileContent content)
 		throws FileNotFoundException, PSTException, IOException
 	{
 		// attempt to open the file.
-		in = new RandomAccessFile(fileName, "r");
+		this.in = content;
 
 		// get the first 4 bytes, should be !BDN
 		try {
@@ -179,7 +199,7 @@ public class PSTFile {
 	 * @throws IOException
 	 * @throws PSTException
 	 */
-	private void processNameToIdMap(RandomAccessFile in)
+	private void processNameToIdMap(PSTFileContent in)
 		throws IOException, PSTException
 	{
 
@@ -447,7 +467,7 @@ public class PSTFile {
 	/**
 	 * get the handle to the file we are currently accessing
 	 */
-	public RandomAccessFile getFileHandle() {
+	public PSTFileContent getFileHandle() {
 		return this.in;
 	}
 	
@@ -561,7 +581,7 @@ public class PSTFile {
 	 * @throws IOException
 	 * @throws PSTException
 	 */
-	private byte[] findBtreeItem(RandomAccessFile in, long index, boolean descTree)
+	private byte[] findBtreeItem(PSTFileContent in, long index, boolean descTree)
 		throws IOException, PSTException
 	{
 

--- a/src/main/java/com/pff/PSTFileContent.java
+++ b/src/main/java/com/pff/PSTFileContent.java
@@ -1,0 +1,12 @@
+package com.pff;
+
+import java.io.IOException;
+
+public abstract class PSTFileContent{
+    public abstract void seek(long index) throws IOException;
+    public abstract long getFilePointer() throws IOException;
+    public abstract int read() throws IOException;
+    public abstract int read(byte[] target) throws IOException;
+    public abstract byte readByte() throws IOException;
+    public abstract void close() throws IOException;
+}

--- a/src/main/java/com/pff/PSTNodeInputStream.java
+++ b/src/main/java/com/pff/PSTNodeInputStream.java
@@ -43,7 +43,7 @@ import java.util.*;
  */
 public class PSTNodeInputStream extends InputStream {
 
-	private RandomAccessFile in;
+	private PSTFileContent in;
 	private PSTFile pstFile;
 	private LinkedList<Long> skipPoints = new LinkedList<Long>();
 	private LinkedList<OffsetIndexItem> indexItems = new LinkedList<OffsetIndexItem>();

--- a/src/main/java/com/pff/PSTNodeInputStream.java
+++ b/src/main/java/com/pff/PSTNodeInputStream.java
@@ -74,7 +74,7 @@ public class PSTNodeInputStream extends InputStream {
 	PSTNodeInputStream(PSTFile pstFile, PSTDescriptorItem descriptorItem)
 			throws IOException, PSTException
 	{
-		this.in = pstFile.getFileHandle();
+		this.in = pstFile.getContentHandle();
 		this.pstFile = pstFile;
 		this.encrypted = pstFile.getEncryptionType() == PSTFile.ENCRYPTION_TYPE_COMPRESSIBLE;
 
@@ -89,7 +89,7 @@ public class PSTNodeInputStream extends InputStream {
 	PSTNodeInputStream(PSTFile pstFile, OffsetIndexItem offsetItem)
 			throws IOException, PSTException
 	{
-		this.in = pstFile.getFileHandle();
+		this.in = pstFile.getContentHandle();
 		this.pstFile = pstFile;
 		this.encrypted = pstFile.getEncryptionType() == PSTFile.ENCRYPTION_TYPE_COMPRESSIBLE;
 		loadFromOffsetItem(offsetItem);

--- a/src/main/java/com/pff/PSTRAFFileContent.java
+++ b/src/main/java/com/pff/PSTRAFFileContent.java
@@ -1,0 +1,33 @@
+package com.pff;
+import java.io.RandomAccessFile;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+public class PSTRAFFileContent extends PSTFileContent{
+    
+    protected RandomAccessFile file;
+    
+    public PSTRAFFileContent(File file) throws FileNotFoundException{
+        this.file = new RandomAccessFile(file, "r");
+    }
+     
+    public void seek(long index) throws IOException{
+        this.file.seek(index);
+    }
+    public long getFilePointer() throws IOException{
+        return this.file.getFilePointer();
+    }
+    public int read() throws IOException{
+        return this.file.read();
+    }
+    public int read(byte[] target) throws IOException{
+        return this.file.read(target);
+    }
+    public byte readByte() throws IOException{
+        return this.file.readByte();
+    }
+    public void close() throws IOException{
+        this.file.close();
+    }
+}

--- a/src/main/java/com/pff/PSTRAFileContent.java
+++ b/src/main/java/com/pff/PSTRAFileContent.java
@@ -18,23 +18,35 @@ public class PSTRAFileContent extends PSTFileContent{
     public void setFile(RandomAccessFile file){
         this.file = file;
     }
-     
+    
+    @Override
     public void seek(long index) throws IOException{
         this.file.seek(index);
     }
+    
+    @Override
     public long getFilePointer() throws IOException{
         return this.file.getFilePointer();
     }
+    
+    @Override
     public int read() throws IOException{
         return this.file.read();
     }
+    
+    @Override
     public int read(byte[] target) throws IOException{
         return this.file.read(target);
     }
+    
+    @Override
     public byte readByte() throws IOException{
         return this.file.readByte();
     }
+    
+    @Override
     public void close() throws IOException{
         this.file.close();
     }
+    
 }

--- a/src/main/java/com/pff/PSTRAFileContent.java
+++ b/src/main/java/com/pff/PSTRAFileContent.java
@@ -4,12 +4,19 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-public class PSTRAFFileContent extends PSTFileContent{
+public class PSTRAFileContent extends PSTFileContent{
     
     protected RandomAccessFile file;
     
-    public PSTRAFFileContent(File file) throws FileNotFoundException{
+    public PSTRAFileContent(File file) throws FileNotFoundException{
         this.file = new RandomAccessFile(file, "r");
+    }
+    
+    public RandomAccessFile getFile(){
+        return this.file;
+    }
+    public void setFile(RandomAccessFile file){
+        this.file = file;
     }
      
     public void seek(long index) throws IOException{


### PR DESCRIPTION
Removes the need for a temporary file when file content is stored as a byte array, and no path to the original file is available