### PR TITLE
Handle case where there's no data for an attachment

### DIFF
--- a/src/main/java/com/pff/PSTAttachment.java
+++ b/src/main/java/com/pff/PSTAttachment.java
@@ -38,6 +38,8 @@ import java.io.InputStream;
 import java.util.Date;
 import java.util.HashMap;
 
+import java.io.ByteArrayInputStream;
+
 /**
  * Class containing attachment information.
  * 
@@ -119,8 +121,10 @@ public class PSTAttachment extends PSTObject {
     public InputStream getFileInputStream() throws IOException, PSTException {
 
         final PSTTableBCItem attachmentDataObject = this.items.get(0x3701);
-
-        if (attachmentDataObject.isExternalValueReference) {
+        
+        if (null == attachmentDataObject) {
+            return new ByteArrayInputStream(new byte[0]);
+        } else if (attachmentDataObject.isExternalValueReference) {
             final PSTDescriptorItem descriptorItemNested = this.localDescriptorItems
                 .get(attachmentDataObject.entryValueReference);
             return new PSTNodeInputStream(this.pstFile, descriptorItemNested);


### PR DESCRIPTION
This fix changes the `getFileInputStream` method to return an empty `InputStream` when there is no data for an attachment.

Returning an empty stream instead of `null` allows downstream parsers like Tika to avoid having to check for null for explicitly and properly or semantically reflects the fact that there is a stream, but it contains no data.