### PR TITLE
Extract interfaces for common PST objects to improve testability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+.idea/
+

--- a/src/main/java/com/pff/IActivity.java
+++ b/src/main/java/com/pff/IActivity.java
@@ -1,0 +1,55 @@
+package com.pff;
+
+import java.util.Date;
+
+public interface IActivity extends IMessage {
+    /**
+     * Type
+     */
+    String getLogType();
+
+    /**
+     * Start
+     */
+    Date getLogStart();
+
+    /**
+     * Duration
+     */
+    int getLogDuration();
+
+    /**
+     * End
+     */
+    Date getLogEnd();
+
+    /**
+     * LogFlags
+     */
+    int getLogFlags();
+
+    /**
+     * DocPrinted
+     */
+    boolean isDocumentPrinted();
+
+    /**
+     * DocSaved
+     */
+    boolean isDocumentSaved();
+
+    /**
+     * DocRouted
+     */
+    boolean isDocumentRouted();
+
+    /**
+     * DocPosted
+     */
+    boolean isDocumentPosted();
+
+    /**
+     * Type Description
+     */
+    String getLogTypeDesc();
+}

--- a/src/main/java/com/pff/IAppointment.java
+++ b/src/main/java/com/pff/IAppointment.java
@@ -1,0 +1,88 @@
+package com.pff;
+
+import java.util.Date;
+
+public interface IAppointment extends IMessage {
+    boolean getSendAsICAL();
+
+    int getBusyStatus();
+
+    boolean getShowAsBusy();
+
+    String getLocation();
+
+    Date getStartTime();
+
+    PSTTimeZone getStartTimeZone();
+
+    Date getEndTime();
+
+    PSTTimeZone getEndTimeZone();
+
+    PSTTimeZone getRecurrenceTimeZone();
+
+    int getDuration();
+
+    int getColor();
+
+    boolean getSubType();
+
+    int getMeetingStatus();
+
+    int getResponseStatus();
+
+    boolean isRecurring();
+
+    Date getRecurrenceBase();
+
+    int getRecurrenceType();
+
+    String getRecurrencePattern();
+
+    byte[] getRecurrenceStructure();
+
+    byte[] getTimezone();
+
+    String getAllAttendees();
+
+    String getToAttendees();
+
+    String getCCAttendees();
+
+    int getAppointmentSequence();
+
+    // online meeting properties
+    boolean isOnlineMeeting();
+
+    int getNetMeetingType();
+
+    String getNetMeetingServer();
+
+    String getNetMeetingOrganizerAlias();
+
+    boolean getNetMeetingAutostart();
+
+    boolean getConferenceServerAllowExternal();
+
+    String getNetMeetingDocumentPathName();
+
+    String getNetShowURL();
+
+    Date getAttendeeCriticalChange();
+
+    Date getOwnerCriticalChange();
+
+    String getConferenceServerPassword();
+
+    boolean getAppointmentCounterProposal();
+
+    boolean isSilent();
+
+    String getRequiredAttendees();
+
+    int getLocaleId();
+
+    PSTGlobalObjectId getGlobalObjectId();
+
+    PSTGlobalObjectId getCleanGlobalObjectId();
+}

--- a/src/main/java/com/pff/IAppointmentRecurrence.java
+++ b/src/main/java/com/pff/IAppointmentRecurrence.java
@@ -1,0 +1,45 @@
+package com.pff;
+
+import java.util.Calendar;
+
+public interface IAppointmentRecurrence {
+    short getExceptionCount();
+
+    PSTAppointmentException getException(int i);
+
+    Calendar[] getDeletedInstanceDates();
+
+    Calendar[] getModifiedInstanceDates();
+
+    short getCalendarType();
+
+    short getPatternType();
+
+    int getPeriod();
+
+    int getPatternSpecific();
+
+    int getFirstDOW();
+
+    int getPatternSpecificNth();
+
+    int getFirstDateTime();
+
+    int getEndType();
+
+    int getOccurrenceCount();
+
+    int getEndDate();
+
+    int getStartTimeOffset();
+
+    PSTTimeZone getTimeZone();
+
+    int getRecurFrequency();
+
+    int getSlidingFlag();
+
+    int getStartDate();
+
+    int getEndTimeOffset();
+}

--- a/src/main/java/com/pff/IAttachment.java
+++ b/src/main/java/com/pff/IAttachment.java
@@ -1,0 +1,96 @@
+package com.pff;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+
+public interface IAttachment extends IObject {
+    int getSize();
+
+    Date getCreationTime();
+
+    Date getModificationTime();
+
+    IMessage getEmbeddedPSTMessage() throws IOException, PSTException;
+
+    InputStream getFileInputStream() throws IOException, PSTException;
+
+    int getFilesize() throws PSTException, IOException;
+
+    /**
+     * Attachment (short) filename ASCII or Unicode string
+     */
+    String getFilename();
+
+    /**
+     * Attachment method Integer 32-bit signed 0 => None (No attachment) 1 => By
+     * value 2 => By reference 3 => By reference resolve 4 => By reference only
+     * 5 => Embedded message 6 => OLE
+     */
+    int getAttachMethod();
+
+    /**
+     * Attachment size
+     */
+    int getAttachSize();
+
+    /**
+     * Attachment number
+     */
+    int getAttachNum();
+
+    /**
+     * Attachment long filename ASCII or Unicode string
+     */
+    String getLongFilename();
+
+    /**
+     * Attachment (short) pathname ASCII or Unicode string
+     */
+    String getPathname();
+
+    /**
+     * Attachment Position Integer 32-bit signed
+     */
+    int getRenderingPosition();
+
+    /**
+     * Attachment long pathname ASCII or Unicode string
+     */
+    String getLongPathname();
+
+    /**
+     * Attachment mime type ASCII or Unicode string
+     */
+    String getMimeTag();
+
+    /**
+     * Attachment mime sequence
+     */
+    int getMimeSequence();
+
+    /**
+     * Attachment Content ID
+     */
+    String getContentId();
+
+    /**
+     * Attachment not available in HTML
+     */
+    boolean isAttachmentInvisibleInHtml();
+
+    /**
+     * Attachment not available in RTF
+     */
+    boolean isAttachmentInvisibleInRTF();
+
+    /**
+     * Attachment is MHTML REF
+     */
+    boolean isAttachmentMhtmlRef();
+
+    /**
+     * Attachment content disposition
+     */
+    String getAttachmentContentDisposition();
+}

--- a/src/main/java/com/pff/IContact.java
+++ b/src/main/java/com/pff/IContact.java
@@ -1,0 +1,552 @@
+package com.pff;
+
+import java.util.Date;
+
+public interface IContact extends IMessage {
+    /**
+     * Contact's Account name
+     */
+    String getAccount();
+
+    /**
+     * Callback telephone number
+     */
+    String getCallbackTelephoneNumber();
+
+    /**
+     * Contact's generational abbreviation FTK: Name suffix
+     */
+    String getGeneration();
+
+    /**
+     * Contacts given name
+     */
+    String getGivenName();
+
+    /**
+     * Contacts Government ID Number
+     */
+    String getGovernmentIdNumber();
+
+    /**
+     * Business/Office Telephone Number
+     */
+    String getBusinessTelephoneNumber();
+
+    /**
+     * Home Telephone Number
+     */
+    String getHomeTelephoneNumber();
+
+    /**
+     * Contacts initials
+     */
+    String getInitials();
+
+    /**
+     * Keyword
+     */
+    String getKeyword();
+
+    /**
+     * Contact's language
+     */
+    String getLanguage();
+
+    /**
+     * Contact's location
+     */
+    String getLocation();
+
+    /**
+     * MHS Common Name
+     */
+    String getMhsCommonName();
+
+    /**
+     * Organizational identification number
+     */
+    String getOrganizationalIdNumber();
+
+    /**
+     * Contact's surname FTK: Last name
+     */
+    String getSurname();
+
+    /**
+     * Original display name
+     */
+    String getOriginalDisplayName();
+
+    /**
+     * Default Postal Address
+     */
+    String getPostalAddress();
+
+    /**
+     * Contact's company name
+     */
+    String getCompanyName();
+
+    /**
+     * Contact's job title FTK: Profession
+     */
+    String getTitle();
+
+    /**
+     * Contact's department name Used in contact item
+     */
+    String getDepartmentName();
+
+    /**
+     * Contact's office location
+     */
+    String getOfficeLocation();
+
+    /**
+     * Primary Telephone
+     */
+    String getPrimaryTelephoneNumber();
+
+    /**
+     * Contact's secondary office (business) phone number
+     */
+    String getBusiness2TelephoneNumber();
+
+    /**
+     * Mobile Phone Number
+     */
+    String getMobileTelephoneNumber();
+
+    /**
+     * Radio Phone Number
+     */
+    String getRadioTelephoneNumber();
+
+    /**
+     * Car Phone Number
+     */
+    String getCarTelephoneNumber();
+
+    /**
+     * Other Phone Number
+     */
+    String getOtherTelephoneNumber();
+
+    /**
+     * Transmittable display name
+     */
+    String getTransmittableDisplayName();
+
+    /**
+     * Pager Phone Number
+     */
+    String getPagerTelephoneNumber();
+
+    /**
+     * Primary Fax Number
+     */
+    String getPrimaryFaxNumber();
+
+    /**
+     * Contact's office (business) fax number
+     */
+    String getBusinessFaxNumber();
+
+    /**
+     * Contact's home fax number
+     */
+    String getHomeFaxNumber();
+
+    /**
+     * Business Address Country
+     */
+    String getBusinessAddressCountry();
+
+    /**
+     * Business Address City
+     */
+    String getBusinessAddressCity();
+
+    /**
+     * Business Address State
+     */
+    String getBusinessAddressStateOrProvince();
+
+    /**
+     * Business Address Street
+     */
+    String getBusinessAddressStreet();
+
+    /**
+     * Business Postal Code
+     */
+    String getBusinessPostalCode();
+
+    /**
+     * Business PO Box
+     */
+    String getBusinessPoBox();
+
+    /**
+     * Telex Number
+     */
+    String getTelexNumber();
+
+    /**
+     * ISDN Number
+     */
+    String getIsdnNumber();
+
+    /**
+     * Assistant Phone Number
+     */
+    String getAssistantTelephoneNumber();
+
+    /**
+     * Home Phone 2
+     */
+    String getHome2TelephoneNumber();
+
+    /**
+     * Assistant�s Name
+     */
+    String getAssistant();
+
+    /**
+     * Hobbies
+     */
+    String getHobbies();
+
+    /**
+     * Middle Name
+     */
+    String getMiddleName();
+
+    /**
+     * Display Name Prefix (Contact Title)
+     */
+    String getDisplayNamePrefix();
+
+    /**
+     * Profession
+     */
+    String getProfession();
+
+    /**
+     * Preferred By Name
+     */
+    String getPreferredByName();
+
+    /**
+     * Spouse�s Name
+     */
+    String getSpouseName();
+
+    /**
+     * Computer Network Name
+     */
+    String getComputerNetworkName();
+
+    /**
+     * Customer ID
+     */
+    String getCustomerId();
+
+    /**
+     * TTY/TDD Phone
+     */
+    String getTtytddPhoneNumber();
+
+    /**
+     * Ftp Site
+     */
+    String getFtpSite();
+
+    /**
+     * Manager�s Name
+     */
+    String getManagerName();
+
+    /**
+     * Nickname
+     */
+    String getNickname();
+
+    /**
+     * Personal Home Page
+     */
+    String getPersonalHomePage();
+
+    /**
+     * Business Home Page
+     */
+    String getBusinessHomePage();
+
+    /**
+     * Note
+     */
+    String getNote();
+
+    String getSMTPAddress();
+
+    /**
+     * Company Main Phone
+     */
+    String getCompanyMainPhoneNumber();
+
+    /**
+     * Children's names
+     */
+    String getChildrensNames();
+
+    /**
+     * Home Address City
+     */
+    String getHomeAddressCity();
+
+    /**
+     * Home Address Country
+     */
+    String getHomeAddressCountry();
+
+    /**
+     * Home Address Postal Code
+     */
+    String getHomeAddressPostalCode();
+
+    /**
+     * Home Address State or Province
+     */
+    String getHomeAddressStateOrProvince();
+
+    /**
+     * Home Address Street
+     */
+    String getHomeAddressStreet();
+
+    /**
+     * Home Address Post Office Box
+     */
+    String getHomeAddressPostOfficeBox();
+
+    /**
+     * Other Address City
+     */
+    String getOtherAddressCity();
+
+    /**
+     * Other Address Country
+     */
+    String getOtherAddressCountry();
+
+    /**
+     * Other Address Postal Code
+     */
+    String getOtherAddressPostalCode();
+
+    /**
+     * Other Address State
+     */
+    String getOtherAddressStateOrProvince();
+
+    /**
+     * Other Address Street
+     */
+    String getOtherAddressStreet();
+
+    /**
+     * Other Address Post Office box
+     */
+    String getOtherAddressPostOfficeBox();
+
+    /**
+     * File under FTK: File as
+     */
+    String getFileUnder();
+
+    /**
+     * Home Address
+     */
+    String getHomeAddress();
+
+    /**
+     * Business Address
+     */
+    String getWorkAddress();
+
+    /**
+     * Other Address
+     */
+    String getOtherAddress();
+
+    /**
+     * Selected Mailing Address
+     */
+    int getPostalAddressId();
+
+    /**
+     * Webpage
+     */
+    String getHtml();
+
+    /**
+     * Business Address City
+     */
+    String getWorkAddressStreet();
+
+    /**
+     * Business Address Street
+     */
+    String getWorkAddressCity();
+
+    /**
+     * Business Address State
+     */
+    String getWorkAddressState();
+
+    /**
+     * Business Address Postal Code
+     */
+    String getWorkAddressPostalCode();
+
+    /**
+     * Business Address Country
+     */
+    String getWorkAddressCountry();
+
+    /**
+     * Business Address Country
+     */
+    String getWorkAddressPostOfficeBox();
+
+    /**
+     * IM Address
+     */
+    String getInstantMessagingAddress();
+
+    /**
+     * E-mail1 Display Name
+     */
+    String getEmail1DisplayName();
+
+    /**
+     * E-mail1 Address Type
+     */
+    String getEmail1AddressType();
+
+    /**
+     * E-mail1 Address
+     */
+    String getEmail1EmailAddress();
+
+    /**
+     * E-mail1 Display Name
+     */
+    String getEmail1OriginalDisplayName();
+
+    /**
+     * E-mail1 type
+     */
+    String getEmail1EmailType();
+
+    /**
+     * E-mail2 display name
+     */
+    String getEmail2DisplayName();
+
+    /**
+     * E-mail2 address type
+     */
+    String getEmail2AddressType();
+
+    /**
+     * E-mail2 e-mail address
+     */
+    String getEmail2EmailAddress();
+
+    /**
+     * E-mail2 original display name
+     */
+    String getEmail2OriginalDisplayName();
+
+    /**
+     * E-mail3 display name
+     */
+    String getEmail3DisplayName();
+
+    /**
+     * E-mail3 address type
+     */
+    String getEmail3AddressType();
+
+    /**
+     * E-mail3 e-mail address
+     */
+    String getEmail3EmailAddress();
+
+    /**
+     * E-mail3 original display name
+     */
+    String getEmail3OriginalDisplayName();
+
+    /**
+     * Fax1 Address Type
+     */
+    String getFax1AddressType();
+
+    /**
+     * Fax1 Email Address
+     */
+    String getFax1EmailAddress();
+
+    /**
+     * Fax1 Original Display Name
+     */
+    String getFax1OriginalDisplayName();
+
+    /**
+     * Fax2 Address Type
+     */
+    String getFax2AddressType();
+
+    /**
+     * Fax2 Email Address
+     */
+    String getFax2EmailAddress();
+
+    /**
+     * Fax2 Original Display Name
+     */
+    String getFax2OriginalDisplayName();
+
+    /**
+     * Fax3 Address Type
+     */
+    String getFax3AddressType();
+
+    /**
+     * Fax3 Email Address
+     */
+    String getFax3EmailAddress();
+
+    /**
+     * Fax3 Original Display Name
+     */
+    String getFax3OriginalDisplayName();
+
+    /**
+     * Free/Busy Location (URL)
+     */
+    String getFreeBusyLocation();
+
+    /**
+     * Birthday
+     */
+    Date getBirthday();
+
+    /**
+     * (Wedding) Anniversary
+     */
+    Date getAnniversary();
+}

--- a/src/main/java/com/pff/IDistList.java
+++ b/src/main/java/com/pff/IDistList.java
@@ -1,0 +1,17 @@
+package com.pff;
+
+import java.io.IOException;
+
+public interface IDistList extends IMessage {
+    /**
+     * Get an array of the members in this distribution list.
+     *
+     * @throws PSTException
+     *             on corrupted data
+     * @throws IOException
+     *             on bad string reading
+     * @return array of entries that can either be PSTDistList.OneOffEntry
+     *         or a PSTObject, generally PSTContact.
+     */
+    Object[] getDistributionListMembers() throws PSTException, IOException;
+}

--- a/src/main/java/com/pff/IFolder.java
+++ b/src/main/java/com/pff/IFolder.java
@@ -1,0 +1,104 @@
+package com.pff;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.Vector;
+
+public interface IFolder extends IObject {
+    /**
+     * get all of the sub folders...
+     * there are not usually thousands, so we just do it in one big operation.
+     *
+     * @return all of the subfolders
+     * @throws PSTException
+     * @throws IOException
+     */
+    Vector<IFolder> getSubFolders() throws PSTException, IOException;
+
+    /**
+     * get some children from the folder
+     * This is implemented as a cursor of sorts, as there could be thousands
+     * and that is just too many to process at once.
+     *
+     * @param numberToReturn
+     * @return bunch of children in this folder
+     * @throws PSTException
+     * @throws IOException
+     */
+    Vector<IObject> getChildren(int numberToReturn) throws PSTException, IOException;
+
+    LinkedList<Integer> getChildDescriptorNodes() throws PSTException, IOException;
+
+    /**
+     * Get the next child of this folder
+     * As there could be thousands of emails, we have these kind of cursor
+     * operations
+     *
+     * @return the next email in the folder or null if at the end of the folder
+     * @throws PSTException
+     * @throws IOException
+     */
+    IObject getNextChild() throws PSTException, IOException;
+
+    /**
+     * move the internal folder cursor to the desired position
+     * position 0 is before the first record.
+     *
+     * @param newIndex
+     */
+    void moveChildCursorTo(int newIndex) throws IOException, PSTException;
+
+    /**
+     * the number of child folders in this folder
+     *
+     * @return number of subfolders as counted
+     * @throws IOException
+     * @throws PSTException
+     */
+    int getSubFolderCount() throws IOException, PSTException;
+
+    /**
+     * the number of emails in this folder
+     * this is the count of emails made by the library and will therefore should
+     * be more accurate than getContentCount
+     *
+     * @return number of emails in this folder (as counted)
+     * @throws IOException
+     * @throws PSTException
+     */
+    int getEmailCount() throws IOException, PSTException;
+
+    int getFolderType();
+
+    /**
+     * the number of emails in this folder
+     * this is as reported by the PST file, for a number calculated by the
+     * library use getEmailCount
+     *
+     * @return number of items as reported by PST File
+     */
+    int getContentCount();
+
+    /**
+     * Amount of unread content items Integer 32-bit signed
+     */
+    int getUnreadCount();
+
+    /**
+     * does this folder have subfolders
+     * once again, read from the PST, use getSubFolderCount if you want to know
+     * what the library makes of it all
+     *
+     * @return has subfolders as reported by the PST File
+     */
+    boolean hasSubfolders();
+
+    String getContainerClass();
+
+    int getAssociateContentCount();
+
+    /**
+     * Container flags Integer 32-bit signed
+     */
+    int getContainerFlags();
+}

--- a/src/main/java/com/pff/IMessage.java
+++ b/src/main/java/com/pff/IMessage.java
@@ -1,0 +1,522 @@
+package com.pff;
+
+import java.io.IOException;
+import java.util.Date;
+
+public interface IMessage extends IObject {
+    String getRTFBody() throws PSTException, IOException;
+
+    /**
+     * get the importance of the email
+     *
+     * @return IMPORTANCE_NORMAL if unknown
+     */
+    int getImportance();
+
+    /**
+     * get the message class for the email
+     *
+     * @return empty string if unknown
+     */
+    String getMessageClass();
+
+    /**
+     * get the subject
+     *
+     * @return empty string if not found
+     */
+    String getSubject();
+
+    /**
+     * get the client submit time
+     *
+     * @return null if not found
+     */
+    Date getClientSubmitTime();
+
+    /**
+     * get received by name
+     *
+     * @return empty string if not found
+     */
+    String getReceivedByName();
+
+    /**
+     * get sent representing name
+     *
+     * @return empty string if not found
+     */
+    String getSentRepresentingName();
+
+    /**
+     * Sent representing address type
+     * Known values are SMTP, EX (Exchange) and UNKNOWN
+     *
+     * @return empty string if not found
+     */
+    String getSentRepresentingAddressType();
+
+    /**
+     * Sent representing email address
+     *
+     * @return empty string if not found
+     */
+    String getSentRepresentingEmailAddress();
+
+    /**
+     * Conversation topic
+     * This is basically the subject from which Fwd:, Re, etc. has been removed
+     *
+     * @return empty string if not found
+     */
+    String getConversationTopic();
+
+    /**
+     * Received by address type
+     * Known values are SMTP, EX (Exchange) and UNKNOWN
+     *
+     * @return empty string if not found
+     */
+    String getReceivedByAddressType();
+
+    /**
+     * Received by email address
+     *
+     * @return empty string if not found
+     */
+    String getReceivedByAddress();
+
+    /**
+     * Transport message headers ASCII or Unicode string These contain the SMTP
+     * e-mail headers.
+     */
+    String getTransportMessageHeaders();
+
+    boolean isRead();
+
+    boolean isUnmodified();
+
+    boolean isSubmitted();
+
+    boolean isUnsent();
+
+    boolean hasAttachments();
+
+    boolean isFromMe();
+
+    boolean isAssociated();
+
+    boolean isResent();
+
+    /**
+     * Acknowledgment mode Integer 32-bit signed
+     */
+    int getAcknowledgementMode();
+
+    /**
+     * Originator delivery report requested set if the sender wants a delivery
+     * report from all recipients 0 = false 0 != true
+     */
+    boolean getOriginatorDeliveryReportRequested();
+
+    /**
+     * Priority Integer 32-bit signed -1 = NonUrgent 0 = Normal 1 = Urgent
+     */
+    int getPriority();
+
+    /**
+     * Read Receipt Requested Boolean 0 = false 0 != true
+     */
+    boolean getReadReceiptRequested();
+
+    /**
+     * Recipient Reassignment Prohibited Boolean 0 = false 0 != true
+     */
+    boolean getRecipientReassignmentProhibited();
+
+    /**
+     * Original sensitivity Integer 32-bit signed the sensitivity of the message
+     * before being replied to or forwarded 0 = None 1 = Personal 2 = Private 3
+     * = Company Confidential
+     */
+    int getOriginalSensitivity();
+
+    /**
+     * Sensitivity Integer 32-bit signed sender's opinion of the sensitivity of
+     * an email 0 = None 1 = Personal 2 = Private 3 = Company Confidential
+     */
+    int getSensitivity();
+
+    /*
+     * Address book search key
+     */
+    byte[] getPidTagSentRepresentingSearchKey();
+
+    /**
+     * Received representing name ASCII or Unicode string
+     */
+    String getRcvdRepresentingName();
+
+    /**
+     * Original subject ASCII or Unicode string
+     */
+    String getOriginalSubject();
+
+    /**
+     * Reply recipients names ASCII or Unicode string
+     */
+    String getReplyRecipientNames();
+
+    /**
+     * My address in To field Boolean
+     */
+    boolean getMessageToMe();
+
+    /**
+     * My address in CC field Boolean
+     */
+    boolean getMessageCcMe();
+
+    /**
+     * Indicates that the receiving mailbox owner is a primary or a carbon copy
+     * (Cc) recipient
+     */
+    boolean getMessageRecipMe();
+
+    /**
+     * Response requested Boolean
+     */
+    boolean getResponseRequested();
+
+    /**
+     * Sent representing address type ASCII or Unicode string Known values are
+     * SMTP, EX (Exchange) and UNKNOWN
+     */
+    String getSentRepresentingAddrtype();
+
+    /**
+     * Original display BCC ASCII or Unicode string
+     */
+    String getOriginalDisplayBcc();
+
+    /**
+     * Original display CC ASCII or Unicode string
+     */
+    String getOriginalDisplayCc();
+
+    /**
+     * Original display TO ASCII or Unicode string
+     */
+    String getOriginalDisplayTo();
+
+    /**
+     * Received representing address type.
+     * Known values are SMTP, EX (Exchange) and UNKNOWN
+     */
+    String getRcvdRepresentingAddrtype();
+
+    /**
+     * Received representing e-mail address
+     */
+    String getRcvdRepresentingEmailAddress();
+
+    /**
+     * Non receipt notification requested
+     */
+    boolean isNonReceiptNotificationRequested();
+
+    /**
+     * Originator non delivery report requested
+     */
+    boolean isOriginatorNonDeliveryReportRequested();
+
+    /**
+     * Recipient type Integer 32-bit signed 0x01 => To 0x02 =>CC
+     */
+    int getRecipientType();
+
+    /**
+     * Reply requested
+     */
+    boolean isReplyRequested();
+
+    /*
+     * Sending mailbox owner's address book entry ID
+     */
+    byte[] getSenderEntryId();
+
+    /**
+     * Sender name
+     */
+    String getSenderName();
+
+    /**
+     * Sender address type.
+     * Known values are SMTP, EX (Exchange) and UNKNOWN
+     */
+    String getSenderAddrtype();
+
+    /**
+     * Sender e-mail address
+     */
+    String getSenderEmailAddress();
+
+    /**
+     * Message size
+     */
+    long getMessageSize();
+
+    /**
+     * Internet article number
+     */
+    int getInternetArticleNumber();
+
+    /*
+     * Server that the client should attempt to send the mail with
+     */
+    String getPrimarySendAccount();
+
+    /*
+     * Server that the client is currently using to send mail
+     */
+    String getNextSendAcct();
+
+    /**
+     * URL computer name postfix
+     */
+    int getURLCompNamePostfix();
+
+    /**
+     * Object type
+     */
+    int getObjectType();
+
+    /**
+     * Delete after submit
+     */
+    boolean getDeleteAfterSubmit();
+
+    /**
+     * Responsibility
+     */
+    boolean getResponsibility();
+
+    /**
+     * Compressed RTF in Sync Boolean
+     */
+    boolean isRTFInSync();
+
+    /**
+     * URL computer name set
+     */
+    boolean isURLCompNameSet();
+
+    /**
+     * Display BCC
+     */
+    String getDisplayBCC();
+
+    /**
+     * Display CC
+     */
+    String getDisplayCC();
+
+    /**
+     * Display To
+     */
+    String getDisplayTo();
+
+    /**
+     * Message delivery time
+     */
+    Date getMessageDeliveryTime();
+
+    /**
+     * Message content properties
+     */
+    int getNativeBodyType();
+
+    /**
+     * Plain text e-mail body
+     */
+    String getBody();
+
+    /*
+     * Plain text body prefix
+     */
+    String getBodyPrefix();
+
+    /**
+     * RTF Sync Body CRC
+     */
+    int getRTFSyncBodyCRC();
+
+    /**
+     * RTF Sync Body character count
+     */
+    int getRTFSyncBodyCount();
+
+    /**
+     * RTF Sync body tag
+     */
+    String getRTFSyncBodyTag();
+
+    /**
+     * RTF whitespace prefix count
+     */
+    int getRTFSyncPrefixCount();
+
+    /**
+     * RTF whitespace tailing count
+     */
+    int getRTFSyncTrailingCount();
+
+    /**
+     * HTML e-mail body
+     */
+    String getBodyHTML();
+
+    /**
+     * Message ID for this email as allocated per rfc2822
+     */
+    String getInternetMessageId();
+
+    /**
+     * In-Reply-To
+     */
+    String getInReplyToId();
+
+    /**
+     * Return Path
+     */
+    String getReturnPath();
+
+    /**
+     * Icon index
+     */
+    int getIconIndex();
+
+    /**
+     * Action flag
+     * This relates to the replying / forwarding of messages.
+     * It is classified as "unknown" atm, so just provided here
+     * in case someone works out what all the various flags mean.
+     */
+    int getActionFlag();
+
+    /**
+     * is the action flag for this item "forward"?
+     */
+    boolean hasForwarded();
+
+    /**
+     * is the action flag for this item "replied"?
+     */
+    boolean hasReplied();
+
+    /**
+     * the date that this item had an action performed (eg. replied or
+     * forwarded)
+     */
+    Date getActionDate();
+
+    /**
+     * Disable full fidelity
+     */
+    boolean getDisableFullFidelity();
+
+    /**
+     * URL computer name
+     * Contains the .eml file name
+     */
+    String getURLCompName();
+
+    /**
+     * Attribute hidden
+     */
+    boolean getAttrHidden();
+
+    /**
+     * Attribute system
+     */
+    boolean getAttrSystem();
+
+    /**
+     * Attribute read only
+     */
+    boolean getAttrReadonly();
+
+    /**
+     * get the number of recipients for this message
+     *
+     * @throws PSTException
+     * @throws IOException
+     */
+    int getNumberOfRecipients() throws PSTException, IOException;
+
+    /**
+     * Start date Filetime
+     */
+    Date getTaskStartDate();
+
+    /**
+     * Due date Filetime
+     */
+    Date getTaskDueDate();
+
+    /**
+     * Is a reminder set on this object?
+     *
+     * @return
+     */
+    boolean getReminderSet();
+
+    int getReminderDelta();
+
+    /**
+     * "flagged" items are actually emails with a due date.
+     * This convience method just checks to see if that is true.
+     */
+    boolean isFlagged();
+
+    /**
+     * get the categories defined for this message
+     */
+    String[] getColorCategories() throws PSTException;
+
+    /**
+     * get the number of attachments for this message
+     *
+     * @throws PSTException
+     * @throws IOException
+     */
+    int getNumberOfAttachments();
+
+    /**
+     * get a specific attachment from this email.
+     *
+     * @param attachmentNumber
+     * @return the attachment at the defined index
+     * @throws PSTException
+     * @throws IOException
+     */
+    IAttachment getAttachment(int attachmentNumber) throws PSTException, IOException;
+
+    /**
+     * get a specific recipient from this email.
+     *
+     * @param recipientNumber
+     * @return the recipient at the defined index
+     * @throws PSTException
+     * @throws IOException
+     */
+    IRecipient getRecipient(int recipientNumber) throws PSTException, IOException;
+
+    String getRecipientsString();
+
+    byte[] getConversationId();
+
+    PSTConversationIndex getConversationIndex();
+
+    boolean isConversationIndexTracking();
+}

--- a/src/main/java/com/pff/IObject.java
+++ b/src/main/java/com/pff/IObject.java
@@ -1,0 +1,61 @@
+package com.pff;
+
+import java.util.Date;
+
+public interface IObject {
+    String getItemsString();
+
+    /**
+     * get the descriptor node for this item
+     * this identifies the location of the node in the BTree and associated info
+     *
+     * @return item's descriptor node
+     */
+    DescriptorIndexNode getDescriptorNode();
+
+    /**
+     * get the descriptor identifier for this item
+     * can be used for loading objects through detectAndLoadPSTObject(PSTFile
+     * theFile, long descriptorIndex)
+     *
+     * @return item's descriptor node identifier
+     */
+    long getDescriptorNodeId();
+
+    int getNodeType();
+
+    Date getDateItem(int identifier);
+
+    String getMessageClass();
+
+    /**
+     * get the display name
+     */
+    String getDisplayName();
+
+    /**
+     * Address type
+     * Known values are SMTP, EX (Exchange) and UNKNOWN
+     */
+    String getAddrType();
+
+    /**
+     * E-mail address
+     */
+    String getEmailAddress();
+
+    /**
+     * Comment
+     */
+    String getComment();
+
+    /**
+     * Creation time
+     */
+    Date getCreationTime();
+
+    /**
+     * Modification time
+     */
+    Date getLastModificationTime();
+}

--- a/src/main/java/com/pff/IRecipient.java
+++ b/src/main/java/com/pff/IRecipient.java
@@ -1,0 +1,17 @@
+package com.pff;
+
+public interface IRecipient {
+    String getDisplayName();
+
+    int getRecipientType();
+
+    String getEmailAddressType();
+
+    String getEmailAddress();
+
+    int getRecipientFlags();
+
+    int getRecipientOrder();
+
+    String getSmtpAddress();
+}

--- a/src/main/java/com/pff/IRss.java
+++ b/src/main/java/com/pff/IRss.java
@@ -1,0 +1,38 @@
+package com.pff;
+
+public interface IRss extends IMessage {
+    /**
+     * Channel
+     */
+    String getPostRssChannelLink();
+
+    /**
+     * Item link
+     */
+    String getPostRssItemLink();
+
+    /**
+     * Item hash Integer 32-bit signed
+     */
+    int getPostRssItemHash();
+
+    /**
+     * Item GUID
+     */
+    String getPostRssItemGuid();
+
+    /**
+     * Channel GUID
+     */
+    String getPostRssChannel();
+
+    /**
+     * Item XML
+     */
+    String getPostRssItemXml();
+
+    /**
+     * Subscription
+     */
+    String getPostRssSubscription();
+}

--- a/src/main/java/com/pff/ITask.java
+++ b/src/main/java/com/pff/ITask.java
@@ -1,0 +1,85 @@
+package com.pff;
+
+import java.util.Date;
+
+public interface ITask extends IMessage {
+    /**
+     * Status Integer 32-bit signed 0x0 => Not started
+     */
+    int getTaskStatus();
+
+    /**
+     * Percent Complete Floating point double precision (64-bit)
+     */
+    double getPercentComplete();
+
+    /**
+     * Is team task Boolean
+     */
+    boolean isTeamTask();
+
+    /**
+     * Date completed Filetime
+     */
+    Date getTaskDateCompleted();
+
+    /**
+     * Actual effort in minutes Integer 32-bit signed
+     */
+    int getTaskActualEffort();
+
+    /**
+     * Total effort in minutes Integer 32-bit signed
+     */
+    int getTaskEstimatedEffort();
+
+    /**
+     * Task version Integer 32-bit signed FTK: Access count
+     */
+    int getTaskVersion();
+
+    /**
+     * Complete Boolean
+     */
+    boolean isTaskComplete();
+
+    /**
+     * Owner ASCII or Unicode string
+     */
+    String getTaskOwner();
+
+    /**
+     * Delegator ASCII or Unicode string
+     */
+    String getTaskAssigner();
+
+    /**
+     * Unknown ASCII or Unicode string
+     */
+    String getTaskLastUser();
+
+    /**
+     * Ordinal Integer 32-bit signed
+     */
+    int getTaskOrdinal();
+
+    /**
+     * Is recurring Boolean
+     */
+    boolean isTaskFRecurring();
+
+    /**
+     * Role ASCII or Unicode string
+     */
+    String getTaskRole();
+
+    /**
+     * Ownership Integer 32-bit signed
+     */
+    int getTaskOwnership();
+
+    /**
+     * Delegation State
+     */
+    int getAcceptanceState();
+}

--- a/src/main/java/com/pff/PSTActivity.java
+++ b/src/main/java/com/pff/PSTActivity.java
@@ -42,7 +42,7 @@ import java.util.HashMap;
  * 
  * @author Richard Johnson
  */
-public class PSTActivity extends PSTMessage {
+public class PSTActivity extends PSTMessage implements IActivity {
 
     /**
      * @param theFile
@@ -69,6 +69,7 @@ public class PSTActivity extends PSTMessage {
     /**
      * Type
      */
+    @Override
     public String getLogType() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008700, PSTFile.PSETID_Log));
     }
@@ -76,6 +77,7 @@ public class PSTActivity extends PSTMessage {
     /**
      * Start
      */
+    @Override
     public Date getLogStart() {
         return this.getDateItem(this.pstFile.getNameToIdMapItem(0x00008706, PSTFile.PSETID_Log));
     }
@@ -83,6 +85,7 @@ public class PSTActivity extends PSTMessage {
     /**
      * Duration
      */
+    @Override
     public int getLogDuration() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008707, PSTFile.PSETID_Log));
     }
@@ -90,6 +93,7 @@ public class PSTActivity extends PSTMessage {
     /**
      * End
      */
+    @Override
     public Date getLogEnd() {
         return this.getDateItem(this.pstFile.getNameToIdMapItem(0x00008708, PSTFile.PSETID_Log));
     }
@@ -97,6 +101,7 @@ public class PSTActivity extends PSTMessage {
     /**
      * LogFlags
      */
+    @Override
     public int getLogFlags() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x0000870c, PSTFile.PSETID_Log));
     }
@@ -104,6 +109,7 @@ public class PSTActivity extends PSTMessage {
     /**
      * DocPrinted
      */
+    @Override
     public boolean isDocumentPrinted() {
         return (this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x0000870e, PSTFile.PSETID_Log)));
     }
@@ -111,6 +117,7 @@ public class PSTActivity extends PSTMessage {
     /**
      * DocSaved
      */
+    @Override
     public boolean isDocumentSaved() {
         return (this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x0000870f, PSTFile.PSETID_Log)));
     }
@@ -118,6 +125,7 @@ public class PSTActivity extends PSTMessage {
     /**
      * DocRouted
      */
+    @Override
     public boolean isDocumentRouted() {
         return (this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x00008710, PSTFile.PSETID_Log)));
     }
@@ -125,6 +133,7 @@ public class PSTActivity extends PSTMessage {
     /**
      * DocPosted
      */
+    @Override
     public boolean isDocumentPosted() {
         return (this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x00008711, PSTFile.PSETID_Log)));
     }
@@ -132,6 +141,7 @@ public class PSTActivity extends PSTMessage {
     /**
      * Type Description
      */
+    @Override
     public String getLogTypeDesc() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008712, PSTFile.PSETID_Log));
     }

--- a/src/main/java/com/pff/PSTAppointment.java
+++ b/src/main/java/com/pff/PSTAppointment.java
@@ -42,7 +42,7 @@ import java.util.HashMap;
  * 
  * @author Richard Johnson
  */
-public class PSTAppointment extends PSTMessage {
+public class PSTAppointment extends PSTMessage implements IAppointment {
 
     PSTAppointment(final PSTFile theFile, final DescriptorIndexNode descriptorIndexNode)
         throws PSTException, IOException {
@@ -54,38 +54,47 @@ public class PSTAppointment extends PSTMessage {
         super(theFile, folderIndexNode, table, localDescriptorItems);
     }
 
+    @Override
     public boolean getSendAsICAL() {
         return (this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x00008200, PSTFile.PSETID_Appointment)));
     }
 
+    @Override
     public int getBusyStatus() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008205, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public boolean getShowAsBusy() {
         return this.getBusyStatus() == 2;
     }
 
+    @Override
     public String getLocation() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008208, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public Date getStartTime() {
         return this.getDateItem(this.pstFile.getNameToIdMapItem(0x0000820d, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public PSTTimeZone getStartTimeZone() {
         return this.getTimeZoneItem(this.pstFile.getNameToIdMapItem(0x0000825e, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public Date getEndTime() {
         return this.getDateItem(this.pstFile.getNameToIdMapItem(0x0000820e, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public PSTTimeZone getEndTimeZone() {
         return this.getTimeZoneItem(this.pstFile.getNameToIdMapItem(0x0000825f, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public PSTTimeZone getRecurrenceTimeZone() {
         final String desc = this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008234, PSTFile.PSETID_Appointment));
         if (desc != null && desc.length() != 0) {
@@ -98,132 +107,164 @@ public class PSTAppointment extends PSTMessage {
         return null;
     }
 
+    @Override
     public int getDuration() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008213, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public int getColor() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008214, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public boolean getSubType() {
         return (this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008215, PSTFile.PSETID_Appointment)) != 0);
     }
 
+    @Override
     public int getMeetingStatus() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008217, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public int getResponseStatus() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008218, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public boolean isRecurring() {
         return this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x00008223, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public Date getRecurrenceBase() {
         return this.getDateItem(this.pstFile.getNameToIdMapItem(0x00008228, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public int getRecurrenceType() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008231, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public String getRecurrencePattern() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008232, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public byte[] getRecurrenceStructure() {
         return this.getBinaryItem(this.pstFile.getNameToIdMapItem(0x00008216, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public byte[] getTimezone() {
         return this.getBinaryItem(this.pstFile.getNameToIdMapItem(0x00008233, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public String getAllAttendees() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008238, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public String getToAttendees() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x0000823b, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public String getCCAttendees() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x0000823c, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public int getAppointmentSequence() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008201, PSTFile.PSETID_Appointment));
     }
 
     // online meeting properties
+    @Override
     public boolean isOnlineMeeting() {
         return (this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x00008240, PSTFile.PSETID_Appointment)));
     }
 
+    @Override
     public int getNetMeetingType() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008241, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public String getNetMeetingServer() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008242, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public String getNetMeetingOrganizerAlias() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008243, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public boolean getNetMeetingAutostart() {
         return (this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008245, PSTFile.PSETID_Appointment)) != 0);
     }
 
+    @Override
     public boolean getConferenceServerAllowExternal() {
         return (this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x00008246, PSTFile.PSETID_Appointment)));
     }
 
+    @Override
     public String getNetMeetingDocumentPathName() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008247, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public String getNetShowURL() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008248, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public Date getAttendeeCriticalChange() {
         return this.getDateItem(this.pstFile.getNameToIdMapItem(0x00000001, PSTFile.PSETID_Meeting));
     }
 
+    @Override
     public Date getOwnerCriticalChange() {
         return this.getDateItem(this.pstFile.getNameToIdMapItem(0x0000001a, PSTFile.PSETID_Meeting));
     }
 
+    @Override
     public String getConferenceServerPassword() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008249, PSTFile.PSETID_Appointment));
     }
 
+    @Override
     public boolean getAppointmentCounterProposal() {
         return (this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x00008257, PSTFile.PSETID_Appointment)));
     }
 
+    @Override
     public boolean isSilent() {
         return (this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x00000004, PSTFile.PSETID_Meeting)));
     }
 
+    @Override
     public String getRequiredAttendees() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00000006, PSTFile.PSETID_Meeting));
     }
 
+    @Override
     public int getLocaleId() {
         return this.getIntItem(0x3ff1);
     }
 
+    @Override
     public PSTGlobalObjectId getGlobalObjectId() {
         return new PSTGlobalObjectId(
             this.getBinaryItem(this.pstFile.getNameToIdMapItem(0x00000003, PSTFile.PSETID_Meeting)));
     }
 
+    @Override
     public PSTGlobalObjectId getCleanGlobalObjectId() {
         return new PSTGlobalObjectId(
             this.getBinaryItem(this.pstFile.getNameToIdMapItem(0x00000023, PSTFile.PSETID_Meeting)));

--- a/src/main/java/com/pff/PSTAppointmentException.java
+++ b/src/main/java/com/pff/PSTAppointmentException.java
@@ -194,12 +194,12 @@ public class PSTAppointmentException {
     // Allow access to an embedded message for
     // properties that don't have access methods here.
     //
-    public PSTAppointment getEmbeddedMessage() {
+    public IAppointment getEmbeddedMessage() {
         return this.embeddedMessage;
     }
 
     PSTAppointmentException(final byte[] recurrencePattern, int offset, final int writerVersion2,
-        final PSTAppointment appt) {
+        final IAppointment appt) {
         this.writerVersion2 = writerVersion2;
         final int initialOffset = offset;
         this.appt = appt;
@@ -339,7 +339,7 @@ public class PSTAppointmentException {
         this.extendedLength = offset - initialOffset;
     }
 
-    void setEmbeddedMessage(final PSTAppointment embeddedMessage) {
+    void setEmbeddedMessage(final IAppointment embeddedMessage) {
         this.embeddedMessage = embeddedMessage;
     }
 
@@ -363,8 +363,8 @@ public class PSTAppointmentException {
     private byte[] WideCharSubject = null;
     private int WideCharLocationLength = 0;
     private byte[] WideCharLocation = null;
-    private PSTAppointment embeddedMessage = null;
-    private final PSTAppointment appt;
+    private IAppointment embeddedMessage = null;
+    private final IAppointment appt;
     private final int length;
     private int extendedLength;
 

--- a/src/main/java/com/pff/PSTAppointmentRecurrence.java
+++ b/src/main/java/com/pff/PSTAppointmentRecurrence.java
@@ -50,14 +50,16 @@ import java.util.SimpleTimeZone;
  *
  */
 
-public class PSTAppointmentRecurrence {
+public class PSTAppointmentRecurrence implements IAppointmentRecurrence {
 
     // Access methods
 
+    @Override
     public short getExceptionCount() {
         return this.ExceptionCount;
     }
 
+    @Override
     public PSTAppointmentException getException(final int i) {
         if (i < 0 || i >= this.ExceptionCount) {
             return null;
@@ -65,79 +67,97 @@ public class PSTAppointmentRecurrence {
         return this.Exceptions[i];
     }
 
+    @Override
     public Calendar[] getDeletedInstanceDates() {
         return this.DeletedInstanceDates;
     }
 
+    @Override
     public Calendar[] getModifiedInstanceDates() {
         return this.ModifiedInstanceDates;
     }
 
+    @Override
     public short getCalendarType() {
         return this.CalendarType;
     }
 
+    @Override
     public short getPatternType() {
         return this.PatternType;
     }
 
+    @Override
     public int getPeriod() {
         return this.Period;
     }
 
+    @Override
     public int getPatternSpecific() {
         return this.PatternSpecific;
     }
 
+    @Override
     public int getFirstDOW() {
         return this.FirstDOW;
     }
 
+    @Override
     public int getPatternSpecificNth() {
         return this.PatternSpecificNth;
     }
 
+    @Override
     public int getFirstDateTime() {
         return this.FirstDateTime;
     }
 
+    @Override
     public int getEndType() {
         return this.EndType;
     }
 
+    @Override
     public int getOccurrenceCount() {
         return this.OccurrenceCount;
     }
 
+    @Override
     public int getEndDate() {
         return this.EndDate;
     }
 
+    @Override
     public int getStartTimeOffset() {
         return this.StartTimeOffset;
     }
 
+    @Override
     public PSTTimeZone getTimeZone() {
         return this.RecurrenceTimeZone;
     }
 
+    @Override
     public int getRecurFrequency() {
         return this.RecurFrequency;
     }
 
+    @Override
     public int getSlidingFlag() {
         return this.SlidingFlag;
     }
 
+    @Override
     public int getStartDate() {
         return this.StartDate;
     }
 
+    @Override
     public int getEndTimeOffset() {
         return this.EndTimeOffset;
     }
 
-    public PSTAppointmentRecurrence(final byte[] recurrencePattern, final PSTAppointment appt, final PSTTimeZone tz) {
+    public PSTAppointmentRecurrence(final byte[] recurrencePattern, final IAppointment appt, final PSTTimeZone tz) {
         this.RecurrenceTimeZone = tz;
         final SimpleTimeZone stz = this.RecurrenceTimeZone.getSimpleTimeZone();
 
@@ -255,7 +275,7 @@ public class PSTAppointmentRecurrence {
         // http://msdn.microsoft.com/en-us/library/cc979209(office.12).aspx
 
         // Get attachments, if any
-        PSTAttachment[] attachments = new PSTAttachment[appt.getNumberOfAttachments()];
+        IAttachment[] attachments = new IAttachment[appt.getNumberOfAttachments()];
         for (int i = 0; i < attachments.length; ++i) {
             try {
                 attachments[i] = appt.getAttachment(i);
@@ -265,17 +285,17 @@ public class PSTAppointmentRecurrence {
             }
         }
 
-        PSTAppointment embeddedMessage = null;
+        IAppointment embeddedMessage = null;
         for (int i = 0; i < this.ExceptionCount; ++i) {
             try {
                 // Match up an attachment to this exception...
-                for (final PSTAttachment attachment : attachments) {
+                for (final IAttachment attachment : attachments) {
                     if (attachment != null) {
-                        final PSTMessage message = attachment.getEmbeddedPSTMessage();
+                        final IMessage message = attachment.getEmbeddedPSTMessage();
                         if (!(message instanceof PSTAppointment)) {
                             continue;
                         }
-                        embeddedMessage = (PSTAppointment) message;
+                        embeddedMessage = (IAppointment) message;
                         final Date replaceTime = embeddedMessage.getRecurrenceBase();
                         /*
                          * SimpleDateFormat f = new

--- a/src/main/java/com/pff/PSTAttachment.java
+++ b/src/main/java/com/pff/PSTAttachment.java
@@ -45,13 +45,14 @@ import java.io.ByteArrayInputStream;
  * 
  * @author Richard Johnson
  */
-public class PSTAttachment extends PSTObject {
+public class PSTAttachment extends PSTObject implements IAttachment {
 
     PSTAttachment(final PSTFile theFile, final PSTTableBC table,
         final HashMap<Integer, PSTDescriptorItem> localDescriptorItems) {
         super(theFile, null, table, localDescriptorItems);
     }
 
+    @Override
     public int getSize() {
         return this.getIntItem(0x0e20);
     }
@@ -61,11 +62,13 @@ public class PSTAttachment extends PSTObject {
         return this.getDateItem(0x3007);
     }
 
+    @Override
     public Date getModificationTime() {
         return this.getDateItem(0x3008);
     }
 
-    public PSTMessage getEmbeddedPSTMessage() throws IOException, PSTException {
+    @Override
+    public IMessage getEmbeddedPSTMessage() throws IOException, PSTException {
         PSTNodeInputStream in = null;
         if (this.getIntItem(0x3705) == PSTAttachment.ATTACHMENT_METHOD_EMBEDDED) {
             final PSTTableBCItem item = this.items.get(0x3701);
@@ -118,6 +121,7 @@ public class PSTAttachment extends PSTObject {
         return null;
     }
 
+    @Override
     public InputStream getFileInputStream() throws IOException, PSTException {
 
         final PSTTableBCItem attachmentDataObject = this.items.get(0x3701);
@@ -135,6 +139,7 @@ public class PSTAttachment extends PSTObject {
 
     }
 
+    @Override
     public int getFilesize() throws PSTException, IOException {
         final PSTTableBCItem attachmentDataObject = this.items.get(0x3701);
         if (attachmentDataObject.isExternalValueReference) {
@@ -157,6 +162,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment (short) filename ASCII or Unicode string
      */
+    @Override
     public String getFilename() {
         return this.getStringItem(0x3704);
     }
@@ -174,6 +180,7 @@ public class PSTAttachment extends PSTObject {
      * value 2 => By reference 3 => By reference resolve 4 => By reference only
      * 5 => Embedded message 6 => OLE
      */
+    @Override
     public int getAttachMethod() {
         return this.getIntItem(0x3705);
     }
@@ -181,6 +188,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment size
      */
+    @Override
     public int getAttachSize() {
         return this.getIntItem(0x0e20);
     }
@@ -188,6 +196,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment number
      */
+    @Override
     public int getAttachNum() {
         return this.getIntItem(0x0e21);
     }
@@ -195,6 +204,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment long filename ASCII or Unicode string
      */
+    @Override
     public String getLongFilename() {
         return this.getStringItem(0x3707);
     }
@@ -202,6 +212,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment (short) pathname ASCII or Unicode string
      */
+    @Override
     public String getPathname() {
         return this.getStringItem(0x3708);
     }
@@ -209,6 +220,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment Position Integer 32-bit signed
      */
+    @Override
     public int getRenderingPosition() {
         return this.getIntItem(0x370b);
     }
@@ -216,6 +228,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment long pathname ASCII or Unicode string
      */
+    @Override
     public String getLongPathname() {
         return this.getStringItem(0x370d);
     }
@@ -223,6 +236,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment mime type ASCII or Unicode string
      */
+    @Override
     public String getMimeTag() {
         return this.getStringItem(0x370e);
     }
@@ -230,6 +244,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment mime sequence
      */
+    @Override
     public int getMimeSequence() {
         return this.getIntItem(0x3710);
     }
@@ -237,6 +252,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment Content ID
      */
+    @Override
     public String getContentId() {
         return this.getStringItem(0x3712);
     }
@@ -244,6 +260,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment not available in HTML
      */
+    @Override
     public boolean isAttachmentInvisibleInHtml() {
         final int actionFlag = this.getIntItem(0x3714);
         return ((actionFlag & 0x1) > 0);
@@ -252,6 +269,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment not available in RTF
      */
+    @Override
     public boolean isAttachmentInvisibleInRTF() {
         final int actionFlag = this.getIntItem(0x3714);
         return ((actionFlag & 0x2) > 0);
@@ -260,6 +278,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment is MHTML REF
      */
+    @Override
     public boolean isAttachmentMhtmlRef() {
         final int actionFlag = this.getIntItem(0x3714);
         return ((actionFlag & 0x4) > 0);
@@ -268,6 +287,7 @@ public class PSTAttachment extends PSTObject {
     /**
      * Attachment content disposition
      */
+    @Override
     public String getAttachmentContentDisposition() {
         return this.getStringItem(0x3716);
     }

--- a/src/main/java/com/pff/PSTContact.java
+++ b/src/main/java/com/pff/PSTContact.java
@@ -42,7 +42,7 @@ import java.util.HashMap;
  * 
  * @author Richard Johnson
  */
-public class PSTContact extends PSTMessage {
+public class PSTContact extends PSTMessage implements IContact {
 
     /**
      * @param theFile
@@ -69,6 +69,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contact's Account name
      */
+    @Override
     public String getAccount() {
         return this.getStringItem(0x3a00);
     }
@@ -76,6 +77,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Callback telephone number
      */
+    @Override
     public String getCallbackTelephoneNumber() {
         return this.getStringItem(0x3a02);
     }
@@ -83,6 +85,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contact's generational abbreviation FTK: Name suffix
      */
+    @Override
     public String getGeneration() {
         return this.getStringItem(0x3a05);
     }
@@ -90,6 +93,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contacts given name
      */
+    @Override
     public String getGivenName() {
         return this.getStringItem(0x3a06);
     }
@@ -97,6 +101,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contacts Government ID Number
      */
+    @Override
     public String getGovernmentIdNumber() {
         return this.getStringItem(0x3a07);
     }
@@ -104,6 +109,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business/Office Telephone Number
      */
+    @Override
     public String getBusinessTelephoneNumber() {
         return this.getStringItem(0x3a08);
     }
@@ -111,6 +117,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Home Telephone Number
      */
+    @Override
     public String getHomeTelephoneNumber() {
         return this.getStringItem(0x3a09);
     }
@@ -118,6 +125,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contacts initials
      */
+    @Override
     public String getInitials() {
         return this.getStringItem(0x3a0a);
     }
@@ -125,6 +133,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Keyword
      */
+    @Override
     public String getKeyword() {
         return this.getStringItem(0x3a0b);
     }
@@ -132,6 +141,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contact's language
      */
+    @Override
     public String getLanguage() {
         return this.getStringItem(0x3a0c);
     }
@@ -139,6 +149,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contact's location
      */
+    @Override
     public String getLocation() {
         return this.getStringItem(0x3a0d);
     }
@@ -146,6 +157,7 @@ public class PSTContact extends PSTMessage {
     /**
      * MHS Common Name
      */
+    @Override
     public String getMhsCommonName() {
         return this.getStringItem(0x3a0f);
     }
@@ -153,6 +165,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Organizational identification number
      */
+    @Override
     public String getOrganizationalIdNumber() {
         return this.getStringItem(0x3a10);
     }
@@ -160,6 +173,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contact's surname FTK: Last name
      */
+    @Override
     public String getSurname() {
         return this.getStringItem(0x3a11);
     }
@@ -167,6 +181,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Original display name
      */
+    @Override
     public String getOriginalDisplayName() {
         return this.getStringItem(0x3a13);
     }
@@ -174,6 +189,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Default Postal Address
      */
+    @Override
     public String getPostalAddress() {
         return this.getStringItem(0x3a15);
     }
@@ -181,6 +197,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contact's company name
      */
+    @Override
     public String getCompanyName() {
         return this.getStringItem(0x3a16);
     }
@@ -188,6 +205,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contact's job title FTK: Profession
      */
+    @Override
     public String getTitle() {
         return this.getStringItem(0x3a17);
     }
@@ -195,6 +213,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contact's department name Used in contact item
      */
+    @Override
     public String getDepartmentName() {
         return this.getStringItem(0x3a18);
     }
@@ -202,6 +221,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contact's office location
      */
+    @Override
     public String getOfficeLocation() {
         return this.getStringItem(0x3a19);
     }
@@ -209,6 +229,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Primary Telephone
      */
+    @Override
     public String getPrimaryTelephoneNumber() {
         return this.getStringItem(0x3a1a);
     }
@@ -216,6 +237,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contact's secondary office (business) phone number
      */
+    @Override
     public String getBusiness2TelephoneNumber() {
         return this.getStringItem(0x3a1b);
     }
@@ -223,6 +245,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Mobile Phone Number
      */
+    @Override
     public String getMobileTelephoneNumber() {
         return this.getStringItem(0x3a1c);
     }
@@ -230,6 +253,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Radio Phone Number
      */
+    @Override
     public String getRadioTelephoneNumber() {
         return this.getStringItem(0x3a1d);
     }
@@ -237,6 +261,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Car Phone Number
      */
+    @Override
     public String getCarTelephoneNumber() {
         return this.getStringItem(0x3a1e);
     }
@@ -244,6 +269,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Other Phone Number
      */
+    @Override
     public String getOtherTelephoneNumber() {
         return this.getStringItem(0x3a1f);
     }
@@ -251,6 +277,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Transmittable display name
      */
+    @Override
     public String getTransmittableDisplayName() {
         return this.getStringItem(0x3a20);
     }
@@ -258,6 +285,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Pager Phone Number
      */
+    @Override
     public String getPagerTelephoneNumber() {
         return this.getStringItem(0x3a21);
     }
@@ -265,6 +293,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Primary Fax Number
      */
+    @Override
     public String getPrimaryFaxNumber() {
         return this.getStringItem(0x3a23);
     }
@@ -272,6 +301,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contact's office (business) fax number
      */
+    @Override
     public String getBusinessFaxNumber() {
         return this.getStringItem(0x3a24);
     }
@@ -279,6 +309,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Contact's home fax number
      */
+    @Override
     public String getHomeFaxNumber() {
         return this.getStringItem(0x3a25);
     }
@@ -286,6 +317,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Address Country
      */
+    @Override
     public String getBusinessAddressCountry() {
         return this.getStringItem(0x3a26);
     }
@@ -293,6 +325,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Address City
      */
+    @Override
     public String getBusinessAddressCity() {
         return this.getStringItem(0x3a27);
     }
@@ -300,6 +333,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Address State
      */
+    @Override
     public String getBusinessAddressStateOrProvince() {
         return this.getStringItem(0x3a28);
     }
@@ -307,6 +341,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Address Street
      */
+    @Override
     public String getBusinessAddressStreet() {
         return this.getStringItem(0x3a29);
     }
@@ -314,6 +349,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Postal Code
      */
+    @Override
     public String getBusinessPostalCode() {
         return this.getStringItem(0x3a2a);
     }
@@ -321,6 +357,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business PO Box
      */
+    @Override
     public String getBusinessPoBox() {
         return this.getStringItem(0x3a2b);
     }
@@ -328,6 +365,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Telex Number
      */
+    @Override
     public String getTelexNumber() {
         return this.getStringItem(0x3a2c);
     }
@@ -335,6 +373,7 @@ public class PSTContact extends PSTMessage {
     /**
      * ISDN Number
      */
+    @Override
     public String getIsdnNumber() {
         return this.getStringItem(0x3a2d);
     }
@@ -342,6 +381,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Assistant Phone Number
      */
+    @Override
     public String getAssistantTelephoneNumber() {
         return this.getStringItem(0x3a2e);
     }
@@ -349,6 +389,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Home Phone 2
      */
+    @Override
     public String getHome2TelephoneNumber() {
         return this.getStringItem(0x3a2f);
     }
@@ -356,6 +397,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Assistant�s Name
      */
+    @Override
     public String getAssistant() {
         return this.getStringItem(0x3a30);
     }
@@ -363,6 +405,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Hobbies
      */
+    @Override
     public String getHobbies() {
         return this.getStringItem(0x3a43);
     }
@@ -370,6 +413,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Middle Name
      */
+    @Override
     public String getMiddleName() {
         return this.getStringItem(0x3a44);
     }
@@ -377,6 +421,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Display Name Prefix (Contact Title)
      */
+    @Override
     public String getDisplayNamePrefix() {
         return this.getStringItem(0x3a45);
     }
@@ -384,6 +429,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Profession
      */
+    @Override
     public String getProfession() {
         return this.getStringItem(0x3a46);
     }
@@ -391,6 +437,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Preferred By Name
      */
+    @Override
     public String getPreferredByName() {
         return this.getStringItem(0x3a47);
     }
@@ -398,6 +445,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Spouse�s Name
      */
+    @Override
     public String getSpouseName() {
         return this.getStringItem(0x3a48);
     }
@@ -405,6 +453,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Computer Network Name
      */
+    @Override
     public String getComputerNetworkName() {
         return this.getStringItem(0x3a49);
     }
@@ -412,6 +461,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Customer ID
      */
+    @Override
     public String getCustomerId() {
         return this.getStringItem(0x3a4a);
     }
@@ -419,6 +469,7 @@ public class PSTContact extends PSTMessage {
     /**
      * TTY/TDD Phone
      */
+    @Override
     public String getTtytddPhoneNumber() {
         return this.getStringItem(0x3a4b);
     }
@@ -426,6 +477,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Ftp Site
      */
+    @Override
     public String getFtpSite() {
         return this.getStringItem(0x3a4c);
     }
@@ -433,6 +485,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Manager�s Name
      */
+    @Override
     public String getManagerName() {
         return this.getStringItem(0x3a4e);
     }
@@ -440,6 +493,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Nickname
      */
+    @Override
     public String getNickname() {
         return this.getStringItem(0x3a4f);
     }
@@ -447,6 +501,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Personal Home Page
      */
+    @Override
     public String getPersonalHomePage() {
         return this.getStringItem(0x3a50);
     }
@@ -454,6 +509,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Home Page
      */
+    @Override
     public String getBusinessHomePage() {
         return this.getStringItem(0x3a51);
     }
@@ -461,6 +517,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Note
      */
+    @Override
     public String getNote() {
         return this.getStringItem(0x6619);
     }
@@ -473,6 +530,7 @@ public class PSTContact extends PSTMessage {
         return "";
     }
 
+    @Override
     public String getSMTPAddress() {
         return this.getNamedStringItem(0x00008084);
     }
@@ -480,6 +538,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Company Main Phone
      */
+    @Override
     public String getCompanyMainPhoneNumber() {
         return this.getStringItem(0x3a57);
     }
@@ -487,6 +546,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Children's names
      */
+    @Override
     public String getChildrensNames() {
         return this.getStringItem(0x3a58);
     }
@@ -494,6 +554,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Home Address City
      */
+    @Override
     public String getHomeAddressCity() {
         return this.getStringItem(0x3a59);
     }
@@ -501,6 +562,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Home Address Country
      */
+    @Override
     public String getHomeAddressCountry() {
         return this.getStringItem(0x3a5a);
     }
@@ -508,6 +570,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Home Address Postal Code
      */
+    @Override
     public String getHomeAddressPostalCode() {
         return this.getStringItem(0x3a5b);
     }
@@ -515,6 +578,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Home Address State or Province
      */
+    @Override
     public String getHomeAddressStateOrProvince() {
         return this.getStringItem(0x3a5c);
     }
@@ -522,6 +586,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Home Address Street
      */
+    @Override
     public String getHomeAddressStreet() {
         return this.getStringItem(0x3a5d);
     }
@@ -529,6 +594,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Home Address Post Office Box
      */
+    @Override
     public String getHomeAddressPostOfficeBox() {
         return this.getStringItem(0x3a5e);
     }
@@ -536,6 +602,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Other Address City
      */
+    @Override
     public String getOtherAddressCity() {
         return this.getStringItem(0x3a5f);
     }
@@ -543,6 +610,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Other Address Country
      */
+    @Override
     public String getOtherAddressCountry() {
         return this.getStringItem(0x3a60);
     }
@@ -550,6 +618,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Other Address Postal Code
      */
+    @Override
     public String getOtherAddressPostalCode() {
         return this.getStringItem(0x3a61);
     }
@@ -557,6 +626,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Other Address State
      */
+    @Override
     public String getOtherAddressStateOrProvince() {
         return this.getStringItem(0x3a62);
     }
@@ -564,6 +634,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Other Address Street
      */
+    @Override
     public String getOtherAddressStreet() {
         return this.getStringItem(0x3a63);
     }
@@ -571,6 +642,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Other Address Post Office box
      */
+    @Override
     public String getOtherAddressPostOfficeBox() {
         return this.getStringItem(0x3a64);
     }
@@ -582,6 +654,7 @@ public class PSTContact extends PSTMessage {
     /**
      * File under FTK: File as
      */
+    @Override
     public String getFileUnder() {
         return this.getNamedStringItem(0x00008005);
     }
@@ -589,6 +662,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Home Address
      */
+    @Override
     public String getHomeAddress() {
         return this.getNamedStringItem(0x0000801a);
     }
@@ -596,6 +670,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Address
      */
+    @Override
     public String getWorkAddress() {
         return this.getNamedStringItem(0x0000801b);
     }
@@ -603,6 +678,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Other Address
      */
+    @Override
     public String getOtherAddress() {
         return this.getNamedStringItem(0x0000801c);
     }
@@ -610,6 +686,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Selected Mailing Address
      */
+    @Override
     public int getPostalAddressId() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008022, PSTFile.PSETID_Address));
     }
@@ -617,6 +694,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Webpage
      */
+    @Override
     public String getHtml() {
         return this.getNamedStringItem(0x0000802b);
     }
@@ -624,6 +702,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Address City
      */
+    @Override
     public String getWorkAddressStreet() {
         return this.getNamedStringItem(0x00008045);
     }
@@ -631,6 +710,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Address Street
      */
+    @Override
     public String getWorkAddressCity() {
         return this.getNamedStringItem(0x00008046);
     }
@@ -638,6 +718,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Address State
      */
+    @Override
     public String getWorkAddressState() {
         return this.getNamedStringItem(0x00008047);
     }
@@ -645,6 +726,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Address Postal Code
      */
+    @Override
     public String getWorkAddressPostalCode() {
         return this.getNamedStringItem(0x00008048);
     }
@@ -652,6 +734,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Address Country
      */
+    @Override
     public String getWorkAddressCountry() {
         return this.getNamedStringItem(0x00008049);
     }
@@ -659,6 +742,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Business Address Country
      */
+    @Override
     public String getWorkAddressPostOfficeBox() {
         return this.getNamedStringItem(0x0000804A);
     }
@@ -666,6 +750,7 @@ public class PSTContact extends PSTMessage {
     /**
      * IM Address
      */
+    @Override
     public String getInstantMessagingAddress() {
         return this.getNamedStringItem(0x00008062);
     }
@@ -673,6 +758,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail1 Display Name
      */
+    @Override
     public String getEmail1DisplayName() {
         return this.getNamedStringItem(0x00008080);
     }
@@ -680,6 +766,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail1 Address Type
      */
+    @Override
     public String getEmail1AddressType() {
         return this.getNamedStringItem(0x00008082);
     }
@@ -687,6 +774,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail1 Address
      */
+    @Override
     public String getEmail1EmailAddress() {
         return this.getNamedStringItem(0x00008083);
     }
@@ -694,6 +782,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail1 Display Name
      */
+    @Override
     public String getEmail1OriginalDisplayName() {
         return this.getNamedStringItem(0x00008084);
     }
@@ -701,6 +790,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail1 type
      */
+    @Override
     public String getEmail1EmailType() {
         return this.getNamedStringItem(0x00008087);
     }
@@ -708,6 +798,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail2 display name
      */
+    @Override
     public String getEmail2DisplayName() {
         return this.getNamedStringItem(0x00008090);
     }
@@ -715,6 +806,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail2 address type
      */
+    @Override
     public String getEmail2AddressType() {
         return this.getNamedStringItem(0x00008092);
     }
@@ -722,6 +814,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail2 e-mail address
      */
+    @Override
     public String getEmail2EmailAddress() {
         return this.getNamedStringItem(0x00008093);
     }
@@ -729,6 +822,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail2 original display name
      */
+    @Override
     public String getEmail2OriginalDisplayName() {
         return this.getNamedStringItem(0x00008094);
     }
@@ -736,6 +830,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail3 display name
      */
+    @Override
     public String getEmail3DisplayName() {
         return this.getNamedStringItem(0x000080a0);
     }
@@ -743,6 +838,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail3 address type
      */
+    @Override
     public String getEmail3AddressType() {
         return this.getNamedStringItem(0x000080a2);
     }
@@ -750,6 +846,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail3 e-mail address
      */
+    @Override
     public String getEmail3EmailAddress() {
         return this.getNamedStringItem(0x000080a3);
     }
@@ -757,6 +854,7 @@ public class PSTContact extends PSTMessage {
     /**
      * E-mail3 original display name
      */
+    @Override
     public String getEmail3OriginalDisplayName() {
         return this.getNamedStringItem(0x000080a4);
     }
@@ -764,6 +862,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Fax1 Address Type
      */
+    @Override
     public String getFax1AddressType() {
         return this.getNamedStringItem(0x000080b2);
     }
@@ -771,6 +870,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Fax1 Email Address
      */
+    @Override
     public String getFax1EmailAddress() {
         return this.getNamedStringItem(0x000080b3);
     }
@@ -778,6 +878,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Fax1 Original Display Name
      */
+    @Override
     public String getFax1OriginalDisplayName() {
         return this.getNamedStringItem(0x000080b4);
     }
@@ -785,6 +886,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Fax2 Address Type
      */
+    @Override
     public String getFax2AddressType() {
         return this.getNamedStringItem(0x000080c2);
     }
@@ -792,6 +894,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Fax2 Email Address
      */
+    @Override
     public String getFax2EmailAddress() {
         return this.getNamedStringItem(0x000080c3);
     }
@@ -799,6 +902,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Fax2 Original Display Name
      */
+    @Override
     public String getFax2OriginalDisplayName() {
         return this.getNamedStringItem(0x000080c4);
     }
@@ -806,6 +910,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Fax3 Address Type
      */
+    @Override
     public String getFax3AddressType() {
         return this.getNamedStringItem(0x000080d2);
     }
@@ -813,6 +918,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Fax3 Email Address
      */
+    @Override
     public String getFax3EmailAddress() {
         return this.getNamedStringItem(0x000080d3);
     }
@@ -820,6 +926,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Fax3 Original Display Name
      */
+    @Override
     public String getFax3OriginalDisplayName() {
         return this.getNamedStringItem(0x000080d4);
     }
@@ -827,6 +934,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Free/Busy Location (URL)
      */
+    @Override
     public String getFreeBusyLocation() {
         return this.getNamedStringItem(0x000080d8);
     }
@@ -834,6 +942,7 @@ public class PSTContact extends PSTMessage {
     /**
      * Birthday
      */
+    @Override
     public Date getBirthday() {
         return this.getDateItem(0x3a42);
     }
@@ -841,6 +950,7 @@ public class PSTContact extends PSTMessage {
     /**
      * (Wedding) Anniversary
      */
+    @Override
     public Date getAnniversary() {
         return this.getDateItem(0x3a41);
     }

--- a/src/main/java/com/pff/PSTDistList.java
+++ b/src/main/java/com/pff/PSTDistList.java
@@ -42,7 +42,7 @@ import java.util.HashMap;
  * 
  * @author Richard Johnson
  */
-public class PSTDistList extends PSTMessage {
+public class PSTDistList extends PSTMessage implements IDistList {
 
     /**
      * constructor.
@@ -221,6 +221,7 @@ public class PSTDistList extends PSTMessage {
      * @return array of entries that can either be PSTDistList.OneOffEntry
      *         or a PSTObject, generally PSTContact.
      */
+    @Override
     public Object[] getDistributionListMembers() throws PSTException, IOException {
         final PSTTableBCItem item = this.items.get(this.pstFile.getNameToIdMapItem(0x8055, PSTFile.PSETID_Address));
         Object[] out = {};

--- a/src/main/java/com/pff/PSTFolder.java
+++ b/src/main/java/com/pff/PSTFolder.java
@@ -51,7 +51,7 @@ import java.util.Vector;
  * 
  * @author Richard Johnson
  */
-public class PSTFolder extends PSTObject {
+public class PSTFolder extends PSTObject implements IFolder {
 
     /**
      * a constructor for the rest of us...
@@ -86,14 +86,15 @@ public class PSTFolder extends PSTObject {
      * @throws PSTException
      * @throws IOException
      */
-    public Vector<PSTFolder> getSubFolders() throws PSTException, IOException {
-        final Vector<PSTFolder> output = new Vector<>();
+    @Override
+    public Vector<IFolder> getSubFolders() throws PSTException, IOException {
+        final Vector<IFolder> output = new Vector<>();
         try {
             this.initSubfoldersTable();
             final List<HashMap<Integer, PSTTable7CItem>> itemMapSet = this.subfoldersTable.getItems();
             for (final HashMap<Integer, PSTTable7CItem> itemMap : itemMapSet) {
                 final PSTTable7CItem item = itemMap.get(26610);
-                final PSTFolder folder = (PSTFolder) PSTObject.detectAndLoadPSTObject(this.pstFile,
+                final IFolder folder = (IFolder) PSTObject.detectAndLoadPSTObject(this.pstFile,
                     item.entryValueReference);
                 output.add(folder);
             }
@@ -218,10 +219,11 @@ public class PSTFolder extends PSTObject {
      * @throws PSTException
      * @throws IOException
      */
-    public Vector<PSTObject> getChildren(final int numberToReturn) throws PSTException, IOException {
+    @Override
+    public Vector<IObject> getChildren(final int numberToReturn) throws PSTException, IOException {
         this.initEmailsTable();
 
-        final Vector<PSTObject> output = new Vector<>();
+        final Vector<IObject> output = new Vector<>();
         if (this.emailsTable != null) {
             final List<HashMap<Integer, PSTTable7CItem>> rows = this.emailsTable.getItems(this.currentEmailIndex,
                 numberToReturn);
@@ -235,7 +237,7 @@ public class PSTFolder extends PSTObject {
                 final PSTTable7CItem emailRow = rows.get(x).get(0x67F2);
                 final DescriptorIndexNode childDescriptor = this.pstFile
                     .getDescriptorIndexNode(emailRow.entryValueReference);
-                final PSTObject child = PSTObject.detectAndLoadPSTObject(this.pstFile, childDescriptor);
+                final IObject child = PSTObject.detectAndLoadPSTObject(this.pstFile, childDescriptor);
                 output.add(child);
                 this.currentEmailIndex++;
             }
@@ -249,7 +251,7 @@ public class PSTFolder extends PSTObject {
                     break;
                 }
                 final DescriptorIndexNode childDescriptor = iterator.next();
-                final PSTObject child = PSTObject.detectAndLoadPSTObject(this.pstFile, childDescriptor);
+                final IObject child = PSTObject.detectAndLoadPSTObject(this.pstFile, childDescriptor);
                 output.add(child);
                 this.currentEmailIndex++;
             }
@@ -258,6 +260,7 @@ public class PSTFolder extends PSTObject {
         return output;
     }
 
+    @Override
     public LinkedList<Integer> getChildDescriptorNodes() throws PSTException, IOException {
         this.initEmailsTable();
         if (this.emailsTable == null) {
@@ -289,7 +292,8 @@ public class PSTFolder extends PSTObject {
      * @throws PSTException
      * @throws IOException
      */
-    public PSTObject getNextChild() throws PSTException, IOException {
+    @Override
+    public IObject getNextChild() throws PSTException, IOException {
         this.initEmailsTable();
 
         if (this.emailsTable != null) {
@@ -303,7 +307,7 @@ public class PSTFolder extends PSTObject {
             final PSTTable7CItem emailRow = rows.get(0).get(0x67F2);
             final DescriptorIndexNode childDescriptor = this.pstFile
                 .getDescriptorIndexNode(emailRow.entryValueReference);
-            final PSTObject child = PSTObject.detectAndLoadPSTObject(this.pstFile, childDescriptor);
+            final IObject child = PSTObject.detectAndLoadPSTObject(this.pstFile, childDescriptor);
             this.currentEmailIndex++;
 
             return child;
@@ -315,7 +319,7 @@ public class PSTFolder extends PSTObject {
             }
             // get the emails from the rows
             final DescriptorIndexNode childDescriptor = this.fallbackEmailsTable.get(this.currentEmailIndex);
-            final PSTObject child = PSTObject.detectAndLoadPSTObject(this.pstFile, childDescriptor);
+            final IObject child = PSTObject.detectAndLoadPSTObject(this.pstFile, childDescriptor);
             this.currentEmailIndex++;
             return child;
         }
@@ -328,6 +332,7 @@ public class PSTFolder extends PSTObject {
      * 
      * @param newIndex
      */
+    @Override
     public void moveChildCursorTo(int newIndex) throws IOException, PSTException {
         this.initEmailsTable();
 
@@ -348,6 +353,7 @@ public class PSTFolder extends PSTObject {
      * @throws IOException
      * @throws PSTException
      */
+    @Override
     public int getSubFolderCount() throws IOException, PSTException {
         this.initSubfoldersTable();
         if (this.subfoldersTable != null) {
@@ -366,6 +372,7 @@ public class PSTFolder extends PSTObject {
      * @throws IOException
      * @throws PSTException
      */
+    @Override
     public int getEmailCount() throws IOException, PSTException {
         this.initEmailsTable();
         if (this.emailsTable == null) {
@@ -374,6 +381,7 @@ public class PSTFolder extends PSTObject {
         return this.emailsTable.getRowCount();
     }
 
+    @Override
     public int getFolderType() {
         return this.getIntItem(0x3601);
     }
@@ -385,6 +393,7 @@ public class PSTFolder extends PSTObject {
      * 
      * @return number of items as reported by PST File
      */
+    @Override
     public int getContentCount() {
         return this.getIntItem(0x3602);
     }
@@ -392,6 +401,7 @@ public class PSTFolder extends PSTObject {
     /**
      * Amount of unread content items Integer 32-bit signed
      */
+    @Override
     public int getUnreadCount() {
         return this.getIntItem(0x3603);
     }
@@ -403,14 +413,17 @@ public class PSTFolder extends PSTObject {
      * 
      * @return has subfolders as reported by the PST File
      */
+    @Override
     public boolean hasSubfolders() {
         return (this.getIntItem(0x360a) != 0);
     }
 
+    @Override
     public String getContainerClass() {
         return this.getStringItem(0x3613);
     }
 
+    @Override
     public int getAssociateContentCount() {
         return this.getIntItem(0x3617);
     }
@@ -418,6 +431,7 @@ public class PSTFolder extends PSTObject {
     /**
      * Container flags Integer 32-bit signed
      */
+    @Override
     public int getContainerFlags() {
         return this.getIntItem(0x3600);
     }

--- a/src/main/java/com/pff/PSTMessage.java
+++ b/src/main/java/com/pff/PSTMessage.java
@@ -49,7 +49,7 @@ import java.util.HashMap;
  * 
  * @author Richard Johnson
  */
-public class PSTMessage extends PSTObject {
+public class PSTMessage extends PSTObject implements IMessage {
 
     public static final int IMPORTANCE_LOW = 0;
     public static final int IMPORTANCE_NORMAL = 1;
@@ -64,6 +64,7 @@ public class PSTMessage extends PSTObject {
         super(theFile, folderIndexNode, table, localDescriptorItems);
     }
 
+    @Override
     public String getRTFBody() throws PSTException, IOException {
         // do we have an entry for it?
         if (this.items.containsKey(0x1009)) {
@@ -87,6 +88,7 @@ public class PSTMessage extends PSTObject {
      * 
      * @return IMPORTANCE_NORMAL if unknown
      */
+    @Override
     public int getImportance() {
         return this.getIntItem(0x0017, IMPORTANCE_NORMAL);
     }
@@ -106,6 +108,7 @@ public class PSTMessage extends PSTObject {
      * 
      * @return empty string if not found
      */
+    @Override
     public String getSubject() {
         String subject = this.getStringItem(0x0037);
 
@@ -132,6 +135,7 @@ public class PSTMessage extends PSTObject {
      * 
      * @return null if not found
      */
+    @Override
     public Date getClientSubmitTime() {
         return this.getDateItem(0x0039);
     }
@@ -141,6 +145,7 @@ public class PSTMessage extends PSTObject {
      * 
      * @return empty string if not found
      */
+    @Override
     public String getReceivedByName() {
         return this.getStringItem(0x0040);
     }
@@ -150,6 +155,7 @@ public class PSTMessage extends PSTObject {
      * 
      * @return empty string if not found
      */
+    @Override
     public String getSentRepresentingName() {
         return this.getStringItem(0x0042);
     }
@@ -160,6 +166,7 @@ public class PSTMessage extends PSTObject {
      * 
      * @return empty string if not found
      */
+    @Override
     public String getSentRepresentingAddressType() {
         return this.getStringItem(0x0064);
     }
@@ -169,6 +176,7 @@ public class PSTMessage extends PSTObject {
      * 
      * @return empty string if not found
      */
+    @Override
     public String getSentRepresentingEmailAddress() {
         return this.getStringItem(0x0065);
     }
@@ -179,6 +187,7 @@ public class PSTMessage extends PSTObject {
      * 
      * @return empty string if not found
      */
+    @Override
     public String getConversationTopic() {
         return this.getStringItem(0x0070);
     }
@@ -189,6 +198,7 @@ public class PSTMessage extends PSTObject {
      * 
      * @return empty string if not found
      */
+    @Override
     public String getReceivedByAddressType() {
         return this.getStringItem(0x0075);
     }
@@ -198,6 +208,7 @@ public class PSTMessage extends PSTObject {
      * 
      * @return empty string if not found
      */
+    @Override
     public String getReceivedByAddress() {
         return this.getStringItem(0x0076);
     }
@@ -206,38 +217,47 @@ public class PSTMessage extends PSTObject {
      * Transport message headers ASCII or Unicode string These contain the SMTP
      * e-mail headers.
      */
+    @Override
     public String getTransportMessageHeaders() {
         return this.getStringItem(0x007d);
     }
 
+    @Override
     public boolean isRead() {
         return ((this.getIntItem(0x0e07) & 0x01) != 0);
     }
 
+    @Override
     public boolean isUnmodified() {
         return ((this.getIntItem(0x0e07) & 0x02) != 0);
     }
 
+    @Override
     public boolean isSubmitted() {
         return ((this.getIntItem(0x0e07) & 0x04) != 0);
     }
 
+    @Override
     public boolean isUnsent() {
         return ((this.getIntItem(0x0e07) & 0x08) != 0);
     }
 
+    @Override
     public boolean hasAttachments() {
         return ((this.getIntItem(0x0e07) & 0x10) != 0);
     }
 
+    @Override
     public boolean isFromMe() {
         return ((this.getIntItem(0x0e07) & 0x20) != 0);
     }
 
+    @Override
     public boolean isAssociated() {
         return ((this.getIntItem(0x0e07) & 0x40) != 0);
     }
 
+    @Override
     public boolean isResent() {
         return ((this.getIntItem(0x0e07) & 0x80) != 0);
     }
@@ -245,6 +265,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Acknowledgment mode Integer 32-bit signed
      */
+    @Override
     public int getAcknowledgementMode() {
         return this.getIntItem(0x0001);
     }
@@ -253,6 +274,7 @@ public class PSTMessage extends PSTObject {
      * Originator delivery report requested set if the sender wants a delivery
      * report from all recipients 0 = false 0 != true
      */
+    @Override
     public boolean getOriginatorDeliveryReportRequested() {
         return (this.getIntItem(0x0023) != 0);
     }
@@ -261,6 +283,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Priority Integer 32-bit signed -1 = NonUrgent 0 = Normal 1 = Urgent
      */
+    @Override
     public int getPriority() {
         return this.getIntItem(0x0026);
     }
@@ -268,6 +291,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Read Receipt Requested Boolean 0 = false 0 != true
      */
+    @Override
     public boolean getReadReceiptRequested() {
         return (this.getIntItem(0x0029) != 0);
     }
@@ -275,6 +299,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Recipient Reassignment Prohibited Boolean 0 = false 0 != true
      */
+    @Override
     public boolean getRecipientReassignmentProhibited() {
         return (this.getIntItem(0x002b) != 0);
     }
@@ -284,6 +309,7 @@ public class PSTMessage extends PSTObject {
      * before being replied to or forwarded 0 = None 1 = Personal 2 = Private 3
      * = Company Confidential
      */
+    @Override
     public int getOriginalSensitivity() {
         return this.getIntItem(0x002e);
     }
@@ -292,6 +318,7 @@ public class PSTMessage extends PSTObject {
      * Sensitivity Integer 32-bit signed sender's opinion of the sensitivity of
      * an email 0 = None 1 = Personal 2 = Private 3 = Company Confidential
      */
+    @Override
     public int getSensitivity() {
         return this.getIntItem(0x0036);
     }
@@ -305,6 +332,7 @@ public class PSTMessage extends PSTObject {
     /*
      * Address book search key
      */
+    @Override
     public byte[] getPidTagSentRepresentingSearchKey() {
         return this.getBinaryItem(0x003b);
     }
@@ -312,6 +340,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Received representing name ASCII or Unicode string
      */
+    @Override
     public String getRcvdRepresentingName() {
         return this.getStringItem(0x0044);
     }
@@ -319,6 +348,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Original subject ASCII or Unicode string
      */
+    @Override
     public String getOriginalSubject() {
         return this.getStringItem(0x0049);
     }
@@ -327,6 +357,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Reply recipients names ASCII or Unicode string
      */
+    @Override
     public String getReplyRecipientNames() {
         return this.getStringItem(0x0050);
     }
@@ -334,6 +365,7 @@ public class PSTMessage extends PSTObject {
     /**
      * My address in To field Boolean
      */
+    @Override
     public boolean getMessageToMe() {
         return (this.getIntItem(0x0057) != 0);
     }
@@ -341,6 +373,7 @@ public class PSTMessage extends PSTObject {
     /**
      * My address in CC field Boolean
      */
+    @Override
     public boolean getMessageCcMe() {
         return (this.getIntItem(0x0058) != 0);
     }
@@ -349,6 +382,7 @@ public class PSTMessage extends PSTObject {
      * Indicates that the receiving mailbox owner is a primary or a carbon copy
      * (Cc) recipient
      */
+    @Override
     public boolean getMessageRecipMe() {
         return this.getIntItem(0x0059) != 0;
     }
@@ -356,6 +390,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Response requested Boolean
      */
+    @Override
     public boolean getResponseRequested() {
         return this.getBooleanItem(0x0063);
     }
@@ -364,6 +399,7 @@ public class PSTMessage extends PSTObject {
      * Sent representing address type ASCII or Unicode string Known values are
      * SMTP, EX (Exchange) and UNKNOWN
      */
+    @Override
     public String getSentRepresentingAddrtype() {
         return this.getStringItem(0x0064);
     }
@@ -373,6 +409,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Original display BCC ASCII or Unicode string
      */
+    @Override
     public String getOriginalDisplayBcc() {
         return this.getStringItem(0x0072);
     }
@@ -380,6 +417,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Original display CC ASCII or Unicode string
      */
+    @Override
     public String getOriginalDisplayCc() {
         return this.getStringItem(0x0073);
     }
@@ -387,6 +425,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Original display TO ASCII or Unicode string
      */
+    @Override
     public String getOriginalDisplayTo() {
         return this.getStringItem(0x0074);
     }
@@ -395,6 +434,7 @@ public class PSTMessage extends PSTObject {
      * Received representing address type.
      * Known values are SMTP, EX (Exchange) and UNKNOWN
      */
+    @Override
     public String getRcvdRepresentingAddrtype() {
         return this.getStringItem(0x0077);
     }
@@ -402,6 +442,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Received representing e-mail address
      */
+    @Override
     public String getRcvdRepresentingEmailAddress() {
         return this.getStringItem(0x0078);
     }
@@ -413,6 +454,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Non receipt notification requested
      */
+    @Override
     public boolean isNonReceiptNotificationRequested() {
         return (this.getIntItem(0x0c06) != 0);
     }
@@ -420,6 +462,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Originator non delivery report requested
      */
+    @Override
     public boolean isOriginatorNonDeliveryReportRequested() {
         return (this.getIntItem(0x0c08) != 0);
     }
@@ -430,6 +473,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Recipient type Integer 32-bit signed 0x01 => To 0x02 =>CC
      */
+    @Override
     public int getRecipientType() {
         return this.getIntItem(0x0c15);
     }
@@ -437,6 +481,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Reply requested
      */
+    @Override
     public boolean isReplyRequested() {
         return (this.getIntItem(0x0c17) != 0);
     }
@@ -444,6 +489,7 @@ public class PSTMessage extends PSTObject {
     /*
      * Sending mailbox owner's address book entry ID
      */
+    @Override
     public byte[] getSenderEntryId() {
         return this.getBinaryItem(0x0c19);
     }
@@ -451,6 +497,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Sender name
      */
+    @Override
     public String getSenderName() {
         return this.getStringItem(0x0c1a);
     }
@@ -459,6 +506,7 @@ public class PSTMessage extends PSTObject {
      * Sender address type.
      * Known values are SMTP, EX (Exchange) and UNKNOWN
      */
+    @Override
     public String getSenderAddrtype() {
         return this.getStringItem(0x0c1e);
     }
@@ -466,6 +514,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Sender e-mail address
      */
+    @Override
     public String getSenderEmailAddress() {
         return this.getStringItem(0x0c1f);
     }
@@ -477,6 +526,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Message size
      */
+    @Override
     public long getMessageSize() {
         return this.getLongItem(0x0e08);
     }
@@ -484,6 +534,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Internet article number
      */
+    @Override
     public int getInternetArticleNumber() {
         return this.getIntItem(0x0e23);
     }
@@ -491,6 +542,7 @@ public class PSTMessage extends PSTObject {
     /*
      * Server that the client should attempt to send the mail with
      */
+    @Override
     public String getPrimarySendAccount() {
         return this.getStringItem(0x0e28);
     }
@@ -498,6 +550,7 @@ public class PSTMessage extends PSTObject {
     /*
      * Server that the client is currently using to send mail
      */
+    @Override
     public String getNextSendAcct() {
         return this.getStringItem(0x0e29);
     }
@@ -505,6 +558,7 @@ public class PSTMessage extends PSTObject {
     /**
      * URL computer name postfix
      */
+    @Override
     public int getURLCompNamePostfix() {
         return this.getIntItem(0x0e61);
     }
@@ -512,6 +566,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Object type
      */
+    @Override
     public int getObjectType() {
         return this.getIntItem(0x0ffe);
     }
@@ -519,6 +574,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Delete after submit
      */
+    @Override
     public boolean getDeleteAfterSubmit() {
         return ((this.getIntItem(0x0e01)) != 0);
     }
@@ -526,6 +582,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Responsibility
      */
+    @Override
     public boolean getResponsibility() {
         return ((this.getIntItem(0x0e0f)) != 0);
     }
@@ -533,6 +590,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Compressed RTF in Sync Boolean
      */
+    @Override
     public boolean isRTFInSync() {
         return ((this.getIntItem(0x0e1f)) != 0);
     }
@@ -540,6 +598,7 @@ public class PSTMessage extends PSTObject {
     /**
      * URL computer name set
      */
+    @Override
     public boolean isURLCompNameSet() {
         return ((this.getIntItem(0x0e62)) != 0);
     }
@@ -547,6 +606,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Display BCC
      */
+    @Override
     public String getDisplayBCC() {
         return this.getStringItem(0x0e02);
     }
@@ -554,6 +614,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Display CC
      */
+    @Override
     public String getDisplayCC() {
         return this.getStringItem(0x0e03);
     }
@@ -561,6 +622,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Display To
      */
+    @Override
     public String getDisplayTo() {
         return this.getStringItem(0x0e04);
     }
@@ -568,6 +630,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Message delivery time
      */
+    @Override
     public Date getMessageDeliveryTime() {
         return this.getDateItem(0x0e06);
     }
@@ -641,6 +704,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Message content properties
      */
+    @Override
     public int getNativeBodyType() {
         return this.getIntItem(0x1016);
     }
@@ -648,6 +712,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Plain text e-mail body
      */
+    @Override
     public String getBody() {
         String cp = null;
         PSTTableBCItem cpItem = this.items.get(0x3FFD); // PidTagMessageCodepage
@@ -663,6 +728,7 @@ public class PSTMessage extends PSTObject {
     /*
      * Plain text body prefix
      */
+    @Override
     public String getBodyPrefix() {
         return this.getStringItem(0x6619);
     }
@@ -670,6 +736,7 @@ public class PSTMessage extends PSTObject {
     /**
      * RTF Sync Body CRC
      */
+    @Override
     public int getRTFSyncBodyCRC() {
         return this.getIntItem(0x1006);
     }
@@ -677,6 +744,7 @@ public class PSTMessage extends PSTObject {
     /**
      * RTF Sync Body character count
      */
+    @Override
     public int getRTFSyncBodyCount() {
         return this.getIntItem(0x1007);
     }
@@ -684,6 +752,7 @@ public class PSTMessage extends PSTObject {
     /**
      * RTF Sync body tag
      */
+    @Override
     public String getRTFSyncBodyTag() {
         return this.getStringItem(0x1008);
     }
@@ -691,6 +760,7 @@ public class PSTMessage extends PSTObject {
     /**
      * RTF whitespace prefix count
      */
+    @Override
     public int getRTFSyncPrefixCount() {
         return this.getIntItem(0x1010);
     }
@@ -698,6 +768,7 @@ public class PSTMessage extends PSTObject {
     /**
      * RTF whitespace tailing count
      */
+    @Override
     public int getRTFSyncTrailingCount() {
         return this.getIntItem(0x1011);
     }
@@ -705,6 +776,7 @@ public class PSTMessage extends PSTObject {
     /**
      * HTML e-mail body
      */
+    @Override
     public String getBodyHTML() {
         String cp = null;
         PSTTableBCItem cpItem = this.items.get(0x3FDE); // PidTagInternetCodepage
@@ -720,6 +792,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Message ID for this email as allocated per rfc2822
      */
+    @Override
     public String getInternetMessageId() {
         return this.getStringItem(0x1035);
     }
@@ -727,6 +800,7 @@ public class PSTMessage extends PSTObject {
     /**
      * In-Reply-To
      */
+    @Override
     public String getInReplyToId() {
         return this.getStringItem(0x1042);
     }
@@ -734,6 +808,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Return Path
      */
+    @Override
     public String getReturnPath() {
         return this.getStringItem(0x1046);
     }
@@ -741,6 +816,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Icon index
      */
+    @Override
     public int getIconIndex() {
         return this.getIntItem(0x1080);
     }
@@ -751,6 +827,7 @@ public class PSTMessage extends PSTObject {
      * It is classified as "unknown" atm, so just provided here
      * in case someone works out what all the various flags mean.
      */
+    @Override
     public int getActionFlag() {
         return this.getIntItem(0x1081);
     }
@@ -758,6 +835,7 @@ public class PSTMessage extends PSTObject {
     /**
      * is the action flag for this item "forward"?
      */
+    @Override
     public boolean hasForwarded() {
         final int actionFlag = this.getIntItem(0x1081);
         return ((actionFlag & 0x8) > 0);
@@ -766,6 +844,7 @@ public class PSTMessage extends PSTObject {
     /**
      * is the action flag for this item "replied"?
      */
+    @Override
     public boolean hasReplied() {
         final int actionFlag = this.getIntItem(0x1081);
         return ((actionFlag & 0x4) > 0);
@@ -775,6 +854,7 @@ public class PSTMessage extends PSTObject {
      * the date that this item had an action performed (eg. replied or
      * forwarded)
      */
+    @Override
     public Date getActionDate() {
         return this.getDateItem(0x1082);
     }
@@ -782,6 +862,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Disable full fidelity
      */
+    @Override
     public boolean getDisableFullFidelity() {
         return (this.getIntItem(0x10f2) != 0);
     }
@@ -790,6 +871,7 @@ public class PSTMessage extends PSTObject {
      * URL computer name
      * Contains the .eml file name
      */
+    @Override
     public String getURLCompName() {
         return this.getStringItem(0x10f3);
     }
@@ -797,6 +879,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Attribute hidden
      */
+    @Override
     public boolean getAttrHidden() {
         return (this.getIntItem(0x10f4) != 0);
     }
@@ -804,6 +887,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Attribute system
      */
+    @Override
     public boolean getAttrSystem() {
         return (this.getIntItem(0x10f5) != 0);
     }
@@ -811,6 +895,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Attribute read only
      */
+    @Override
     public boolean getAttrReadonly() {
         return (this.getIntItem(0x10f6) != 0);
     }
@@ -848,6 +933,7 @@ public class PSTMessage extends PSTObject {
      * @throws PSTException
      * @throws IOException
      */
+    @Override
     public int getNumberOfRecipients() throws PSTException, IOException {
         this.processRecipients();
 
@@ -890,6 +976,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Start date Filetime
      */
+    @Override
     public Date getTaskStartDate() {
         return this.getDateItem(this.pstFile.getNameToIdMapItem(0x00008104, PSTFile.PSETID_Task));
     }
@@ -897,6 +984,7 @@ public class PSTMessage extends PSTObject {
     /**
      * Due date Filetime
      */
+    @Override
     public Date getTaskDueDate() {
         return this.getDateItem(this.pstFile.getNameToIdMapItem(0x00008105, PSTFile.PSETID_Task));
     }
@@ -906,10 +994,12 @@ public class PSTMessage extends PSTObject {
      * 
      * @return
      */
+    @Override
     public boolean getReminderSet() {
         return this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x00008503, PSTFile.PSETID_Common));
     }
 
+    @Override
     public int getReminderDelta() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008501, PSTFile.PSETID_Common));
     }
@@ -918,6 +1008,7 @@ public class PSTMessage extends PSTObject {
      * "flagged" items are actually emails with a due date.
      * This convience method just checks to see if that is true.
      */
+    @Override
     public boolean isFlagged() {
         return this.getTaskDueDate() != null;
     }
@@ -925,6 +1016,7 @@ public class PSTMessage extends PSTObject {
     /**
      * get the categories defined for this message
      */
+    @Override
     public String[] getColorCategories() throws PSTException {
         final int keywordCategory = this.pstFile.getPublicStringToIdMapItem("Keywords");
 
@@ -973,6 +1065,7 @@ public class PSTMessage extends PSTObject {
      * @throws PSTException
      * @throws IOException
      */
+    @Override
     public int getNumberOfAttachments() {
         try {
             this.processAttachments();
@@ -996,7 +1089,8 @@ public class PSTMessage extends PSTObject {
      * @throws PSTException
      * @throws IOException
      */
-    public PSTAttachment getAttachment(final int attachmentNumber) throws PSTException, IOException {
+    @Override
+    public IAttachment getAttachment(final int attachmentNumber) throws PSTException, IOException {
         this.processAttachments();
 
         int attachmentCount = 0;
@@ -1052,7 +1146,8 @@ public class PSTMessage extends PSTObject {
      * @throws PSTException
      * @throws IOException
      */
-    public PSTRecipient getRecipient(final int recipientNumber) throws PSTException, IOException {
+    @Override
+    public IRecipient getRecipient(final int recipientNumber) throws PSTException, IOException {
         if (recipientNumber >= this.getNumberOfRecipients()
             || recipientNumber >= this.recipientTable.getItems().size()) {
             throw new PSTException("unable to fetch recipient number " + recipientNumber);
@@ -1067,6 +1162,7 @@ public class PSTMessage extends PSTObject {
         return null;
     }
 
+    @Override
     public String getRecipientsString() {
         if (this.recipientTable != null) {
             return this.recipientTable.getItemsString();
@@ -1075,14 +1171,17 @@ public class PSTMessage extends PSTObject {
         return "No recipients table!";
     }
 
+    @Override
     public byte[] getConversationId() {
         return this.getBinaryItem(0x3013);
     }
 
+    @Override
     public PSTConversationIndex getConversationIndex() {
         return new PSTConversationIndex(this.getBinaryItem(0x0071));
     }
 
+    @Override
     public boolean isConversationIndexTracking() {
         return this.getBooleanItem(0x3016, false);
     }

--- a/src/main/java/com/pff/PSTObject.java
+++ b/src/main/java/com/pff/PSTObject.java
@@ -52,7 +52,7 @@ import java.io.UnsupportedEncodingException;
  * 
  * @author Richard Johnson
  */
-public class PSTObject {
+public class PSTObject implements IObject {
 
     public static final int NID_TYPE_HID = 0x00; // Heap node
     public static final int NID_TYPE_INTERNAL = 0x01; // Internal node (section
@@ -115,6 +115,7 @@ public class PSTObject {
                                                                 // view-related
     public static final int NID_TYPE_LTP = 0x1F; // LTP
 
+    @Override
     public String getItemsString() {
         return this.items.toString();
     }
@@ -125,7 +126,7 @@ public class PSTObject {
     protected HashMap<Integer, PSTTableBCItem> items;
     protected HashMap<Integer, PSTDescriptorItem> localDescriptorItems = null;
 
-    protected LinkedHashMap<String, HashMap<DescriptorIndexNode, PSTObject>> children;
+    protected LinkedHashMap<String, HashMap<DescriptorIndexNode, IObject>> children;
 
     protected PSTObject(final PSTFile theFile, final DescriptorIndexNode descriptorIndexNode)
         throws PSTException, IOException {
@@ -173,6 +174,7 @@ public class PSTObject {
      * 
      * @return item's descriptor node
      */
+    @Override
     public DescriptorIndexNode getDescriptorNode() {
         return this.descriptorIndexNode;
     }
@@ -184,6 +186,7 @@ public class PSTObject {
      * 
      * @return item's descriptor node identifier
      */
+    @Override
     public long getDescriptorNodeId() {
         if (this.descriptorIndexNode != null) { // Prevent null pointer
                                                 // exceptions for embedded
@@ -193,6 +196,7 @@ public class PSTObject {
         return 0;
     }
 
+    @Override
     public int getNodeType() {
         return PSTObject.getNodeType(this.descriptorIndexNode.descriptorIdentifier);
     }
@@ -373,6 +377,7 @@ public class PSTObject {
         return null;
     }
 
+    @Override
     public Date getDateItem(final int identifier) {
         if (this.items.containsKey(identifier)) {
             final PSTTableBCItem item = this.items.get(identifier);
@@ -422,6 +427,7 @@ public class PSTObject {
         return null;
     }
 
+    @Override
     public String getMessageClass() {
         return this.getStringItem(0x001a);
     }
@@ -439,6 +445,7 @@ public class PSTObject {
     /**
      * get the display name
      */
+    @Override
     public String getDisplayName() {
         return this.getStringItem(0x3001);
     }
@@ -447,6 +454,7 @@ public class PSTObject {
      * Address type
      * Known values are SMTP, EX (Exchange) and UNKNOWN
      */
+    @Override
     public String getAddrType() {
         return this.getStringItem(0x3002);
     }
@@ -454,6 +462,7 @@ public class PSTObject {
     /**
      * E-mail address
      */
+    @Override
     public String getEmailAddress() {
         return this.getStringItem(0x3003);
     }
@@ -461,6 +470,7 @@ public class PSTObject {
     /**
      * Comment
      */
+    @Override
     public String getComment() {
         return this.getStringItem(0x3004);
     }
@@ -468,6 +478,7 @@ public class PSTObject {
     /**
      * Creation time
      */
+    @Override
     public Date getCreationTime() {
         return this.getDateItem(0x3007);
     }
@@ -475,6 +486,7 @@ public class PSTObject {
     /**
      * Modification time
      */
+    @Override
     public Date getLastModificationTime() {
         return this.getDateItem(0x3008);
     }
@@ -722,7 +734,7 @@ public class PSTObject {
      * @throws IOException
      * @throws PSTException
      */
-    public static PSTObject detectAndLoadPSTObject(final PSTFile theFile, final long descriptorIndex)
+    public static IObject detectAndLoadPSTObject(final PSTFile theFile, final long descriptorIndex)
         throws IOException, PSTException {
         return PSTObject.detectAndLoadPSTObject(theFile, theFile.getDescriptorIndexNode(descriptorIndex));
     }
@@ -737,7 +749,7 @@ public class PSTObject {
      * @throws IOException
      * @throws PSTException
      */
-    static PSTObject detectAndLoadPSTObject(final PSTFile theFile, final DescriptorIndexNode folderIndexNode)
+    static IObject detectAndLoadPSTObject(final PSTFile theFile, final DescriptorIndexNode folderIndexNode)
         throws IOException, PSTException {
         final int nidType = (folderIndexNode.descriptorIdentifier & 0x1F);
         if (nidType == 0x02 || nidType == 0x03 || nidType == 0x04) {
@@ -764,8 +776,8 @@ public class PSTObject {
     }
 
     static PSTMessage createAppropriatePSTMessageObject(final PSTFile theFile,
-        final DescriptorIndexNode folderIndexNode, final PSTTableBC table,
-        final HashMap<Integer, PSTDescriptorItem> localDescriptorItems) {
+                                                      final DescriptorIndexNode folderIndexNode, final PSTTableBC table,
+                                                      final HashMap<Integer, PSTDescriptorItem> localDescriptorItems) {
 
         final PSTTableBCItem item = table.getItems().get(0x001a);
         String messageClass = "";

--- a/src/main/java/com/pff/PSTRecipient.java
+++ b/src/main/java/com/pff/PSTRecipient.java
@@ -43,7 +43,7 @@ import java.util.HashMap;
  *
  *
  */
-public class PSTRecipient {
+public class PSTRecipient implements IRecipient {
     private final HashMap<Integer, PSTTable7CItem> details;
 
     public static final int MAPI_TO = 1;
@@ -54,30 +54,37 @@ public class PSTRecipient {
         this.details = recipientDetails;
     }
 
+    @Override
     public String getDisplayName() {
         return this.getString(0x3001);
     }
 
+    @Override
     public int getRecipientType() {
         return this.getInt(0x0c15);
     }
 
+    @Override
     public String getEmailAddressType() {
         return this.getString(0x3002);
     }
 
+    @Override
     public String getEmailAddress() {
         return this.getString(0x3003);
     }
 
+    @Override
     public int getRecipientFlags() {
         return this.getInt(0x5ffd);
     }
 
+    @Override
     public int getRecipientOrder() {
         return this.getInt(0x5fdf);
     }
 
+    @Override
     public String getSmtpAddress() {
         // If the recipient address type is SMTP,
         // we can simply return the recipient address.

--- a/src/main/java/com/pff/PSTRss.java
+++ b/src/main/java/com/pff/PSTRss.java
@@ -41,7 +41,7 @@ import java.util.HashMap;
  * 
  * @author Richard Johnson
  */
-public class PSTRss extends PSTMessage {
+public class PSTRss extends PSTMessage implements IRss {
 
     /**
      * @param theFile
@@ -68,6 +68,7 @@ public class PSTRss extends PSTMessage {
     /**
      * Channel
      */
+    @Override
     public String getPostRssChannelLink() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008900, PSTFile.PSETID_PostRss));
     }
@@ -75,6 +76,7 @@ public class PSTRss extends PSTMessage {
     /**
      * Item link
      */
+    @Override
     public String getPostRssItemLink() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008901, PSTFile.PSETID_PostRss));
     }
@@ -82,6 +84,7 @@ public class PSTRss extends PSTMessage {
     /**
      * Item hash Integer 32-bit signed
      */
+    @Override
     public int getPostRssItemHash() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008902, PSTFile.PSETID_PostRss));
     }
@@ -89,6 +92,7 @@ public class PSTRss extends PSTMessage {
     /**
      * Item GUID
      */
+    @Override
     public String getPostRssItemGuid() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008903, PSTFile.PSETID_PostRss));
     }
@@ -96,6 +100,7 @@ public class PSTRss extends PSTMessage {
     /**
      * Channel GUID
      */
+    @Override
     public String getPostRssChannel() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008904, PSTFile.PSETID_PostRss));
     }
@@ -103,6 +108,7 @@ public class PSTRss extends PSTMessage {
     /**
      * Item XML
      */
+    @Override
     public String getPostRssItemXml() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008905, PSTFile.PSETID_PostRss));
     }
@@ -110,6 +116,7 @@ public class PSTRss extends PSTMessage {
     /**
      * Subscription
      */
+    @Override
     public String getPostRssSubscription() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008906, PSTFile.PSETID_PostRss));
     }

--- a/src/main/java/com/pff/PSTTask.java
+++ b/src/main/java/com/pff/PSTTask.java
@@ -42,7 +42,7 @@ import java.util.HashMap;
  * 
  * @author Richard Johnson
  */
-public class PSTTask extends PSTMessage {
+public class PSTTask extends PSTMessage implements ITask {
 
     /**
      * @param theFile
@@ -69,6 +69,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Status Integer 32-bit signed 0x0 => Not started
      */
+    @Override
     public int getTaskStatus() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008101, PSTFile.PSETID_Task));
     }
@@ -76,6 +77,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Percent Complete Floating point double precision (64-bit)
      */
+    @Override
     public double getPercentComplete() {
         return this.getDoubleItem(this.pstFile.getNameToIdMapItem(0x00008102, PSTFile.PSETID_Task));
     }
@@ -83,6 +85,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Is team task Boolean
      */
+    @Override
     public boolean isTeamTask() {
         return this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x00008103, PSTFile.PSETID_Task));
     }
@@ -90,6 +93,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Date completed Filetime
      */
+    @Override
     public Date getTaskDateCompleted() {
         return this.getDateItem(this.pstFile.getNameToIdMapItem(0x0000810f, PSTFile.PSETID_Task));
     }
@@ -97,6 +101,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Actual effort in minutes Integer 32-bit signed
      */
+    @Override
     public int getTaskActualEffort() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008110, PSTFile.PSETID_Task));
     }
@@ -104,6 +109,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Total effort in minutes Integer 32-bit signed
      */
+    @Override
     public int getTaskEstimatedEffort() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008111, PSTFile.PSETID_Task));
     }
@@ -111,6 +117,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Task version Integer 32-bit signed FTK: Access count
      */
+    @Override
     public int getTaskVersion() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008112, PSTFile.PSETID_Task));
     }
@@ -118,6 +125,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Complete Boolean
      */
+    @Override
     public boolean isTaskComplete() {
         return this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x0000811c, PSTFile.PSETID_Task));
     }
@@ -125,6 +133,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Owner ASCII or Unicode string
      */
+    @Override
     public String getTaskOwner() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x0000811f, PSTFile.PSETID_Task));
     }
@@ -132,6 +141,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Delegator ASCII or Unicode string
      */
+    @Override
     public String getTaskAssigner() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008121, PSTFile.PSETID_Task));
     }
@@ -139,6 +149,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Unknown ASCII or Unicode string
      */
+    @Override
     public String getTaskLastUser() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008122, PSTFile.PSETID_Task));
     }
@@ -146,6 +157,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Ordinal Integer 32-bit signed
      */
+    @Override
     public int getTaskOrdinal() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008123, PSTFile.PSETID_Task));
     }
@@ -153,6 +165,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Is recurring Boolean
      */
+    @Override
     public boolean isTaskFRecurring() {
         return this.getBooleanItem(this.pstFile.getNameToIdMapItem(0x00008126, PSTFile.PSETID_Task));
     }
@@ -160,6 +173,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Role ASCII or Unicode string
      */
+    @Override
     public String getTaskRole() {
         return this.getStringItem(this.pstFile.getNameToIdMapItem(0x00008127, PSTFile.PSETID_Task));
     }
@@ -167,6 +181,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Ownership Integer 32-bit signed
      */
+    @Override
     public int getTaskOwnership() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x00008129, PSTFile.PSETID_Task));
     }
@@ -174,6 +189,7 @@ public class PSTTask extends PSTMessage {
     /**
      * Delegation State
      */
+    @Override
     public int getAcceptanceState() {
         return this.getIntItem(this.pstFile.getNameToIdMapItem(0x0000812a, PSTFile.PSETID_Task));
     }

--- a/src/main/java/example/Test.java
+++ b/src/main/java/example/Test.java
@@ -2,10 +2,7 @@ package example;
 
 import java.util.Vector;
 
-import com.pff.PSTException;
-import com.pff.PSTFile;
-import com.pff.PSTFolder;
-import com.pff.PSTMessage;
+import com.pff.*;
 
 public class Test {
     public static void main(final String[] args) {
@@ -24,7 +21,7 @@ public class Test {
 
     int depth = -1;
 
-    public void processFolder(final PSTFolder folder) throws PSTException, java.io.IOException {
+    public void processFolder(final IFolder folder) throws PSTException, java.io.IOException {
         this.depth++;
         // the root folder doesn't have a display name
         if (this.depth > 0) {
@@ -34,8 +31,8 @@ public class Test {
 
         // go through the folders...
         if (folder.hasSubfolders()) {
-            final Vector<PSTFolder> childFolders = folder.getSubFolders();
-            for (final PSTFolder childFolder : childFolders) {
+            final Vector<IFolder> childFolders = folder.getSubFolders();
+            for (final IFolder childFolder : childFolders) {
                 this.processFolder(childFolder);
             }
         }

--- a/src/main/java/example/TestGui.java
+++ b/src/main/java/example/TestGui.java
@@ -38,16 +38,7 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
 
-import com.pff.PSTActivity;
-import com.pff.PSTAttachment;
-import com.pff.PSTContact;
-import com.pff.PSTException;
-import com.pff.PSTFile;
-import com.pff.PSTFolder;
-import com.pff.PSTMessage;
-import com.pff.PSTMessageStore;
-import com.pff.PSTRss;
-import com.pff.PSTTask;
+import com.pff.*;
 
 /**
  * @author toweruser
@@ -61,7 +52,7 @@ public class TestGui implements ActionListener {
     private JPanel attachPanel;
     private JLabel attachLabel;
     private JTextField attachText;
-    private PSTMessage selectedMessage;
+    private IMessage selectedMessage;
     private JFrame f;
 
     public TestGui() throws PSTException, IOException {
@@ -251,7 +242,7 @@ public class TestGui implements ActionListener {
                 return;
             }
             if (node.getUserObject() instanceof PSTFolder) {
-                final PSTFolder folderValue = (PSTFolder) node.getUserObject();
+                final IFolder folderValue = (IFolder) node.getUserObject();
                 try {
                     TestGui.this.selectFolder(folderValue);
                 } catch (final Exception err) {
@@ -274,16 +265,16 @@ public class TestGui implements ActionListener {
                 final JTable source = emailTable;
                 TestGui.this.selectedMessage = TestGui.this.emailTableModel.getMessageAtRow(source.getSelectedRow());
                 if (TestGui.this.selectedMessage instanceof PSTContact) {
-                    final PSTContact contact = (PSTContact) TestGui.this.selectedMessage;
+                    final IContact contact = (IContact) TestGui.this.selectedMessage;
                     TestGui.this.emailText.setText(contact.toString());
                 } else if (TestGui.this.selectedMessage instanceof PSTTask) {
-                    final PSTTask task = (PSTTask) TestGui.this.selectedMessage;
+                    final ITask task = (ITask) TestGui.this.selectedMessage;
                     TestGui.this.emailText.setText(task.toString());
                 } else if (TestGui.this.selectedMessage instanceof PSTActivity) {
-                    final PSTActivity journalEntry = (PSTActivity) TestGui.this.selectedMessage;
+                    final IActivity journalEntry = (IActivity) TestGui.this.selectedMessage;
                     TestGui.this.emailText.setText(journalEntry.toString());
                 } else if (TestGui.this.selectedMessage instanceof PSTRss) {
-                    final PSTRss rss = (PSTRss) TestGui.this.selectedMessage;
+                    final IRss rss = (IRss) TestGui.this.selectedMessage;
                     TestGui.this.emailText.setText(rss.toString());
                 } else if (TestGui.this.selectedMessage != null) {
                     // System.out.println(selectedMessage.getMessageClass());
@@ -341,13 +332,13 @@ public class TestGui implements ActionListener {
         this.f.setExtendedState(this.f.getExtendedState() | Frame.MAXIMIZED_BOTH);
     }
 
-    private void buildTree(final DefaultMutableTreeNode top, final PSTFolder theFolder) {
+    private void buildTree(final DefaultMutableTreeNode top, final IFolder theFolder) {
         // this is recursive, try and keep up.
         try {
             final Vector children = theFolder.getSubFolders();
             final Iterator childrenIterator = children.iterator();
             while (childrenIterator.hasNext()) {
-                final PSTFolder folder = (PSTFolder) childrenIterator.next();
+                final IFolder folder = (IFolder) childrenIterator.next();
 
                 final DefaultMutableTreeNode node = new DefaultMutableTreeNode(folder);
 
@@ -370,7 +361,7 @@ public class TestGui implements ActionListener {
             if (this.selectedMessage != null) {
                 final int numAttach = this.selectedMessage.getNumberOfAttachments();
                 for (int x = 0; x < numAttach; x++) {
-                    final PSTAttachment attach = this.selectedMessage.getAttachment(x);
+                    final IAttachment attach = this.selectedMessage.getAttachment(x);
                     String filename = attach.getLongFilename();
                     if (filename.isEmpty()) {
                         filename = attach.getFilename();
@@ -389,7 +380,7 @@ public class TestGui implements ActionListener {
         this.attachText.setText(s.toString());
     }
 
-    void selectFolder(final PSTFolder folder) throws IOException, PSTException {
+    void selectFolder(final IFolder folder) throws IOException, PSTException {
         // load up the non-folder children.
 
         this.emailTableModel.setFolder(folder);
@@ -429,7 +420,7 @@ public class TestGui implements ActionListener {
             }
             try {
                 for (int x = 0; x < numAttach; x++) {
-                    final PSTAttachment attach = this.selectedMessage.getAttachment(x);
+                    final IAttachment attach = this.selectedMessage.getAttachment(x);
                     final InputStream attachmentStream = attach.getFileInputStream();
                     String filename = attach.getLongFilename();
                     if (filename.isEmpty()) {
@@ -474,12 +465,12 @@ public class TestGui implements ActionListener {
 
 class EmailTableModel extends AbstractTableModel {
 
-    PSTFolder theFolder = null;
+    IFolder theFolder = null;
     PSTFile theFile = null;
 
     HashMap cache = new HashMap();
 
-    public EmailTableModel(final PSTFolder theFolder, final PSTFile theFile) {
+    public EmailTableModel(final IFolder theFolder, final PSTFile theFile) {
         super();
 
         this.theFolder = theFolder;
@@ -569,7 +560,7 @@ class EmailTableModel extends AbstractTableModel {
         return false;
     }
 
-    public void setFolder(final PSTFolder theFolder) throws PSTException, IOException {
+    public void setFolder(final IFolder theFolder) throws PSTException, IOException {
         theFolder.moveChildCursorTo(0);
         this.theFolder = theFolder;
         this.cache = new HashMap();

--- a/src/test/java/com/pff/AppointmentTest.java
+++ b/src/test/java/com/pff/AppointmentTest.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Calendar;
-import java.util.Arrays;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,8 +27,8 @@ public class AppointmentTest {
             throws PSTException, IOException, URISyntaxException {
         URL dirUrl = ClassLoader.getSystemResource("dist-list.pst");
         PSTFile pstFile = new PSTFile(new File(dirUrl.toURI()));
-        PSTAppointment appt = (PSTAppointment) PSTObject.detectAndLoadPSTObject(pstFile, 2097348);
-        PSTAppointmentRecurrence r = new PSTAppointmentRecurrence(
+        IAppointment appt = (IAppointment) PSTObject.detectAndLoadPSTObject(pstFile, 2097348);
+        IAppointmentRecurrence r = new PSTAppointmentRecurrence(
                 appt.getRecurrenceStructure(), appt, appt.getRecurrenceTimeZone());
 
 

--- a/src/test/java/com/pff/DistListTest.java
+++ b/src/test/java/com/pff/DistListTest.java
@@ -27,7 +27,7 @@ public class DistListTest {
             throws PSTException, IOException, URISyntaxException {
         URL dirUrl = ClassLoader.getSystemResource("dist-list.pst");
         PSTFile pstFile = new PSTFile(new File(dirUrl.toURI()));
-        PSTDistList obj = (PSTDistList)PSTObject.detectAndLoadPSTObject(pstFile, 2097188);
+        IDistList obj = (IDistList)PSTObject.detectAndLoadPSTObject(pstFile, 2097188);
         Object[] members = obj.getDistributionListMembers();
         Assert.assertEquals("Correct number of members", members.length, 3);
         int numberOfContacts = 0;
@@ -36,7 +36,7 @@ public class DistListTest {
         HashSet<String> displayNames = new HashSet<String>();
         for (Object member : members) {
             if (member instanceof PSTContact) {
-                PSTContact contact = (PSTContact)member;
+                IContact contact = (IContact)member;
                 Assert.assertEquals("Contact email address",
                                     contact.getEmail1EmailAddress(),
                                     "contact1@rjohnson.id.au");

--- a/src/test/java/com/pff/Version36Test.java
+++ b/src/test/java/com/pff/Version36Test.java
@@ -18,12 +18,12 @@ public class Version36Test {
             throws PSTException, IOException, URISyntaxException {
         URL dirUrl = ClassLoader.getSystemResource("example-2013.ost");
         PSTFile pstFile2 = new PSTFile(new File(dirUrl.toURI()));
-        PSTFolder inbox = (PSTFolder)PSTObject.detectAndLoadPSTObject(pstFile2, 8578);
+        IFolder inbox = (IFolder)PSTObject.detectAndLoadPSTObject(pstFile2, 8578);
         Assert.assertEquals(
                 "Number of emails in folder",
                 inbox.getContentCount(),
                 2);
-        PSTMessage msg = (PSTMessage)PSTObject.detectAndLoadPSTObject(pstFile2, 2097284);
+        IMessage msg = (IMessage)PSTObject.detectAndLoadPSTObject(pstFile2, 2097284);
         Assert.assertEquals(
                 "correct email text.",
                 "This is an e-mail message sent automatically by Microsoft "
@@ -33,7 +33,7 @@ public class Version36Test {
     }
 
     int depth = -1;
-    public void processFolder(PSTFolder folder)
+    public void processFolder(IFolder folder)
             throws PSTException, java.io.IOException {
         depth++;
         // the root folder doesn't have a display name
@@ -44,8 +44,8 @@ public class Version36Test {
 
         // go through the folders...
         if (folder.hasSubfolders()) {
-            Vector<PSTFolder> childFolders = folder.getSubFolders();
-            for (PSTFolder childFolder : childFolders) {
+            Vector<IFolder> childFolders = folder.getSubFolders();
+            for (IFolder childFolder : childFolders) {
                 processFolder(childFolder);
             }
         }


### PR DESCRIPTION
First I'd like to say thank you for making this great library. It makes reading PST files so much easier in our Clojure code.

In our experience, we found it a bit hard to write unit tests for our code because we can't mock `PSTObject` and its sub classes - their constructors only have package access and there is a lot going on which is hard to get around without a real PST file.

This change introduces interfaces for `PSTObject`, `PSTMessage` and other related classes, and replace references of those classes with the interfaces where possible.

Let me know what you think about it or whether you want to do it differently.

Cheers.